### PR TITLE
Multiplication Fix

### DIFF
--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -319,9 +319,9 @@ mod tests {
     /// Test that multiplication for the lazy or eager implementaions are identical
     #[test]
     fn mult_perm_lazy_eager(){
+        use crate::perm::builder::PermBuilder;
         let perm1 = Permutation::from(vec![2, 3, 0, 1]);
         let perm2 = Permutation::from(vec![2, 1, 0]);
-        use crate::perm::builder::PermBuilder;
         assert_eq!(perm1.multiply(&perm2), perm1.build_multiply(&perm2).collapse())
     }
 

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -318,11 +318,14 @@ mod tests {
 
     /// Test that multiplication for the lazy or eager implementaions are identical
     #[test]
-    fn mult_perm_lazy_eager(){
+    fn mult_perm_lazy_eager() {
         use crate::perm::builder::PermBuilder;
         let perm1 = Permutation::from(vec![2, 3, 0, 1]);
         let perm2 = Permutation::from(vec![2, 1, 0]);
-        assert_eq!(perm1.multiply(&perm2), perm1.build_multiply(&perm2).collapse())
+        assert_eq!(
+            perm1.multiply(&perm2),
+            perm1.build_multiply(&perm2).collapse()
+        )
     }
 
     #[test]

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -151,7 +151,7 @@ impl Permutation {
         } else {
             let size = max(self.lmp().unwrap_or(0), other.lmp().unwrap_or(0));
             debug_assert!(size > 0);
-            let v = (0..=size).map(|x| self.apply(other.apply(x))).collect();
+            let v = (0..=size).map(|x| other.apply(self.apply(x))).collect();
             Permutation::from_vec_unchecked(v)
         }
     }

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -302,6 +302,28 @@ mod tests {
         assert_eq!(cycle.pow(10), *cycle);
     }
 
+    /// Check that multiplication is correct for non-commuting elements.
+    #[test]
+    fn mult_perm_non_commutative() {
+        let perm1 = Permutation::from(vec![1, 0]);
+        let perm2 = Permutation::from(vec![0, 2, 1]);
+        let expected_perm = Permutation::from(vec![2, 0, 1]);
+        assert_eq!(perm1.multiply(&perm2), expected_perm);
+        let perm1 = Permutation::from(vec![1, 2, 3, 0]);
+        let perm2 = Permutation::from(vec![0, 2, 1]);
+        let expected_perm = Permutation::from(vec![2, 1, 3, 0]);
+        assert_eq!(perm1.multiply(&perm2), expected_perm)
+    }
+
+    /// Test that multiplication for the lazy or eager implementaions are identical
+    #[test]
+    fn mult_perm_lazy_eager(){
+        let perm1 = Permutation::from(vec![2, 3, 0, 1]);
+        let perm2 = Permutation::from(vec![2, 1, 0]);
+        use crate::perm::builder::PermBuilder;
+        assert_eq!(perm1.multiply(&perm2), perm1.build_multiply(&perm2).collapse())
+    }
+
     #[test]
     fn trailing_end_edge() {
         let a = Permutation::from_vec(vec![1, 3, 2, 0]);

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -137,6 +137,7 @@ impl Permutation {
     /// let a = Permutation::from_vec(vec![0, 2, 1]);
     /// let b = a.inv();
     /// assert_eq!(a.multiply(&b), Permutation::id());
+    /// assert_eq!(b.multiply(&a), Permutation::id());
     /// ```
     pub fn multiply(&self, other: &Permutation) -> Self {
         if self.is_id() {


### PR DESCRIPTION
Previously the multiplication for permutations was the wrong way round, if we are composing permutations from the right (i.e (x)fg = ((x)f)g). Previously we had (x)fg = ((x)g)f. The previous tests were only for commuting elements (the identity and inverses of elements), so didn't catch this. The application order has been fixed, with additional tests added for this.

I've also added addition tests that the lazy and eager multiplication agree.