### PR TITLE
Group

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -35,10 +35,7 @@ impl Group {
         assert!(n > 0);
 
         Group::new(&[
-            dbg!(CyclePermutation::from_vec(
-                (1..=n).map(|i| vec![i, 2 * n - i + 1]).collect()
-            ))
-            .into(),
+            CyclePermutation::from_vec((1..=n).map(|i| vec![i, 2 * n - i + 1]).collect()).into(),
             Self::order_n_permutation(2 * n),
         ])
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,3 +1,4 @@
+use crate::perm::export::CyclePermutation;
 use crate::perm::Permutation;
 
 #[derive(Debug, Clone)]
@@ -12,31 +13,77 @@ impl Group {
         }
     }
 
+    pub fn generators(&self) -> &[Permutation] {
+        &self.generators[..]
+    }
+
     fn order_n_permutation(n: usize) -> Permutation {
-        Permutation::from_vec((0..n).map(|i| (i + 1) % n).collect())
+        assert!(n > 0);
+        CyclePermutation::from_vec(vec![(1..=n).collect()]).into()
     }
 
     pub fn trivial() -> Self {
-        Group::new(&[Permutation::id()])
+        // TODO: Should we include the identity here?
+        Group::new(&[])
     }
 
-    pub fn dihedral(n: usize) -> Self {
-        assert!(n >= 2);
-        // TODO: Verify this actually generates D_n
+    /// This generates the dihedral group D_2n.
+    pub fn dihedral_2n(n: usize) -> Self {
+        assert!(n > 0);
+
         Group::new(&[
-            Permutation::from_vec(vec![0, n - 2]),
-            Self::order_n_permutation(n),
+            dbg!(CyclePermutation::from_vec(
+                (1..=n).map(|i| vec![i, 2 * n - i + 1]).collect()
+            ))
+            .into(),
+            Self::order_n_permutation(2 * n),
         ])
     }
 
     pub fn cyclic(n: usize) -> Self {
+        assert!(n > 0);
+
         Group::new(&[Self::order_n_permutation(n)])
     }
 
     pub fn symmetric(n: usize) -> Self {
+        assert!(n > 0);
+
+        if n == 1 {
+            return Self::trivial();
+        }
+
         Group::new(&[
-            Permutation::from_vec(vec![0, 1]),
+            CyclePermutation::from_vec(vec![vec![1, 2]]).into(),
             Self::order_n_permutation(n),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Group;
+
+    #[test]
+    fn trivial_creation() {
+        let g = Group::trivial();
+    }
+
+    #[test]
+    fn cyclic() {
+        let g = Group::cyclic(5);
+        assert_eq!(g.generators().len(), 1);
+    }
+
+    #[test]
+    fn dihedral_creation() {
+        let g = Group::dihedral_2n(4);
+        assert_eq!(g.generators().len(), 2);
+    }
+
+    #[test]
+    fn symmetric_creation() {
+        let g = Group::symmetric(5);
+        assert_eq!(g.generators().len(), 2);
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,0 +1,42 @@
+use crate::perm::Permutation;
+
+#[derive(Debug, Clone)]
+pub struct Group {
+    generators: Vec<Permutation>,
+}
+
+impl Group {
+    pub fn new(generators: &[Permutation]) -> Self {
+        Group {
+            generators: generators.into(),
+        }
+    }
+
+    fn order_n_permutation(n: usize) -> Permutation {
+        Permutation::from_vec((0..n).map(|i| (i + 1) % n).collect())
+    }
+
+    pub fn trivial() -> Self {
+        Group::new(&[Permutation::id()])
+    }
+
+    pub fn dihedral(n: usize) -> Self {
+        assert!(n >= 2);
+        // TODO: Verify this actually generates D_n
+        Group::new(&[
+            Permutation::from_vec(vec![0, n - 2]),
+            Self::order_n_permutation(n),
+        ])
+    }
+
+    pub fn cyclic(n: usize) -> Self {
+        Group::new(&[Self::order_n_permutation(n)])
+    }
+
+    pub fn symmetric(n: usize) -> Self {
+        Group::new(&[
+            Permutation::from_vec(vec![0, 1]),
+            Self::order_n_permutation(n),
+        ])
+    }
+}

--- a/src/group.rs
+++ b/src/group.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn trivial_creation() {
-        let g = Group::trivial();
+        let _g = Group::trivial();
     }
 
     #[test]

--- a/src/group.rs
+++ b/src/group.rs
@@ -7,12 +7,14 @@ pub struct Group {
 }
 
 impl Group {
+    /// Instantiate the group from some generators
     pub fn new(generators: &[Permutation]) -> Self {
         Group {
             generators: generators.into(),
         }
     }
 
+    /// Get a reference to the generators of the group
     pub fn generators(&self) -> &[Permutation] {
         &self.generators[..]
     }
@@ -22,6 +24,7 @@ impl Group {
         CyclePermutation::from_vec(vec![(1..=n).collect()]).into()
     }
 
+    /// Generates the trivial group, which only contains the identity
     pub fn trivial() -> Self {
         // TODO: Should we include the identity here?
         Group::new(&[])
@@ -40,12 +43,14 @@ impl Group {
         ])
     }
 
+    /// Generate the cyclical group on n elements
     pub fn cyclic(n: usize) -> Self {
         assert!(n > 0);
 
         Group::new(&[Self::order_n_permutation(n)])
     }
 
+    /// Generate the symmetric group on n points
     pub fn symmetric(n: usize) -> Self {
         assert!(n > 0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod group;
 pub mod perm;

--- a/src/perm/export/classic.rs
+++ b/src/perm/export/classic.rs
@@ -1,8 +1,9 @@
+use super::cycles::CyclePermutation;
 use crate::perm::Permutation;
 
 /// A permutation, that is on the integral set [1, n].
 /// It is called classical as classically this is how permutations are stored
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ClassicalPermutation(Permutation);
 
 impl ClassicalPermutation {
@@ -45,6 +46,35 @@ impl ClassicalPermutation {
 impl From<Permutation> for ClassicalPermutation {
     fn from(perm: Permutation) -> Self {
         ClassicalPermutation(perm)
+    }
+}
+
+impl From<CyclePermutation> for ClassicalPermutation {
+    fn from(perm: CyclePermutation) -> Self {
+        let cycles = perm.cycles();
+        let n = cycles.iter().flatten().max().cloned().unwrap_or(0);
+
+        if n == 0 {
+            return ClassicalPermutation::id();
+        }
+
+        let mut images = Vec::new();
+
+        for i in 1..=n {
+            let cycle = cycles.iter().find(|cycle| cycle.contains(&i));
+            // In this case the point is fixed
+            if cycle.is_none() {
+                images.push(i);
+                continue;
+            }
+
+            let cycle = cycle.unwrap();
+            // Since we already know it contains it, the unwrap is safe
+            let i_index = cycle.iter().position(|&j| i == j).unwrap();
+            images.push(cycle[(i_index + 1) % cycle.len()]);
+        }
+
+        ClassicalPermutation::from_slice(&images[..])
     }
 }
 

--- a/src/perm/export/cycles.rs
+++ b/src/perm/export/cycles.rs
@@ -9,8 +9,36 @@ pub struct CyclePermutation {
 }
 
 impl CyclePermutation {
+    pub fn from_vec(cycles: Vec<Vec<usize>>) -> Self {
+        use std::collections::HashMap;
+        // Check the element range
+        assert!(cycles.iter().flatten().all(|&i| i > 0));
+
+        // Get the maximal element in the permutation
+        let n = cycles.iter().flatten().max().cloned().unwrap_or(0);
+
+        if n == 0 {
+            return CyclePermutation::from_vec_unchecked(cycles);
+        }
+
+        let mut counts = HashMap::new();
+
+        for i in cycles.iter().flatten() {
+            *counts.entry(*i).or_insert(0) += 1;
+        }
+
+        // Check every element occurs at most once
+        assert!(counts.values().all(|&i| i <= 1));
+
+        CyclePermutation::from_vec_unchecked(cycles)
+    }
+
     fn from_vec_unchecked(v: Vec<Vec<usize>>) -> Self {
         CyclePermutation { cycles: v }
+    }
+
+    pub fn cycles(&self) -> &[Vec<usize>] {
+        &self.cycles[..]
     }
 }
 
@@ -66,21 +94,66 @@ mod tests {
     #[test]
     fn id_cycle() {
         let id: CyclePermutation = ClassicalPermutation::id().into();
-        assert_eq!(id.cycles.len(), 0);
+        assert_eq!(id.cycles().len(), 0);
     }
 
     #[test]
     fn two_cycle() {
-        let perm: CyclePermutation = ClassicalPermutation::from_slice(&vec![2, 5, 4, 3, 1]).into();
-        assert_eq!(perm.cycles.len(), 2);
+        let perm: CyclePermutation = ClassicalPermutation::from_slice(&[2, 5, 4, 3, 1]).into();
+        assert_eq!(perm.cycles().len(), 2);
         assert_eq!(perm.cycles, vec![vec![1, 2, 5], vec![3, 4]])
     }
 
     #[test]
     fn cyclic_perm() {
         let perm: CyclePermutation =
-            ClassicalPermutation::from_slice(&vec![4, 5, 7, 6, 8, 2, 1, 3]).into();
-        assert_eq!(perm.cycles.len(), 1);
+            ClassicalPermutation::from_slice(&[4, 5, 7, 6, 8, 2, 1, 3]).into();
+        assert_eq!(perm.cycles().len(), 1);
         assert_eq!(perm.cycles, vec![vec![1, 4, 6, 2, 5, 8, 3, 7]])
+    }
+
+    #[test]
+    fn create_from_cycles() {
+        let cyclic = CyclePermutation::from_vec(vec![vec![1, 2, 3, 4, 5]]);
+        assert_eq!(cyclic.cycles().len(), 1);
+    }
+
+    #[test]
+    fn create_from_cycles_multiple() {
+        let cyclic = CyclePermutation::from_vec(vec![vec![1, 3], vec![2, 4]]);
+        assert_eq!(cyclic.cycles().len(), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_from_cycles_invalid_zero() {
+        let _cyclic = CyclePermutation::from_vec(vec![vec![1, 3], vec![2, 0]]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_from_cycles_invalid_repetition() {
+        let _cyclic = CyclePermutation::from_vec(vec![vec![1, 3, 4], vec![2, 4]]);
+    }
+
+    #[test]
+    fn cyclical_to_classical_conversion_id() {
+        let cyclic: ClassicalPermutation = CyclePermutation::from_vec(vec![]).into();
+        assert_eq!(cyclic, ClassicalPermutation::id());
+    }
+
+    #[test]
+    fn cyclical_to_classical_derangement() {
+        let cyclic: ClassicalPermutation = CyclePermutation::from_vec(vec![vec![1, 2]]).into();
+        let classic = ClassicalPermutation::from_slice(&[2, 1]);
+        assert_eq!(cyclic, classic);
+    }
+
+    #[test]
+    fn cyclical_to_classical_multiple_cycles() {
+        let cyclic: ClassicalPermutation =
+            CyclePermutation::from_vec(vec![vec![1, 3], vec![2, 4]]).into();
+        let classic = ClassicalPermutation::from_slice(&[3, 4, 1, 2]);
+        assert_eq!(cyclic, classic);
     }
 }

--- a/src/perm/export/cycles.rs
+++ b/src/perm/export/cycles.rs
@@ -48,6 +48,13 @@ impl From<Permutation> for CyclePermutation {
     }
 }
 
+impl From<CyclePermutation> for Permutation {
+    fn from(perm: CyclePermutation) -> Self {
+        let int: ClassicalPermutation = perm.into();
+        int.into()
+    }
+}
+
 impl From<ClassicalPermutation> for CyclePermutation {
     fn from(perm: ClassicalPermutation) -> Self {
         use std::collections::HashSet;

--- a/src/perm/export/cycles.rs
+++ b/src/perm/export/cycles.rs
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn cyclical_to_classical_derangement() {
+    fn cyclical_to_classical_transposition() {
         let cyclic: ClassicalPermutation = CyclePermutation::from_vec(vec![vec![1, 2]]).into();
         let classic = ClassicalPermutation::from_slice(&[2, 1]);
         assert_eq!(cyclic, classic);

--- a/src/perm/export/mod.rs
+++ b/src/perm/export/mod.rs
@@ -5,6 +5,7 @@ use super::Permutation;
 use serde::{Deserialize, Serialize};
 
 pub use classic::ClassicalPermutation;
+pub use cycles::CyclePermutation;
 
 /// A permutation that is easy to export
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
So, I thought about something like this, for both the group "directory" and possibly something that could be helpful for the refactor mentioned in #5 . The idea is that we can have a group object that we use for storing generators. We could then implement the algorithms as methods on this group object. This could enable easy caching if we want to add that in the future. Also, in this PR I've added the conversion from a CyclePermutation to a normal permutation, as that was just easier since generators are often given in that format. 