### PR TITLE
Extended Permutation and Factored Transversal Testing

### DIFF
--- a/src/group/orbit/factored_transversal.rs
+++ b/src/group/orbit/factored_transversal.rs
@@ -210,4 +210,53 @@ mod tests {
             }
         }
     }
+
+    /// Test the factored transversal calculation for a generating set with multiple generators
+    /// when not all elements are in the orbit.
+    #[test]
+    fn multiple_generators_non_full_orbit() {
+        use crate::perm::export::CyclePermutation;
+        let gens: Vec<Permutation> = vec![
+            CyclePermutation::from_vec(vec![vec![1, 2, 6]]).into(),
+            CyclePermutation::from_vec(vec![vec![3, 5, 7]]).into(),
+        ];
+        let fc1 = FactoredTransversal::from_generators(5, &gens[..]);
+        assert_eq!(3, fc1.len());
+        let fc2 = FactoredTransversal::from_generators(4, &gens[..]);
+        assert_eq!(3, fc2.len());
+        let fc3 = FactoredTransversal::from_generators(3, &gens[..]);
+        assert_eq!(1, fc3.len());
+        for i in [0, 1, 5].iter() {
+            // Tests for fc1
+            assert!(fc1.in_orbit(*i));
+            assert_eq!(*i, fc1.representative(*i).unwrap().apply(5));
+            // Tests for fc2
+            assert!(!fc2.in_orbit(*i));
+            assert_eq!(None, fc2.representative(*i));
+            // Tests for fc3
+            assert!(!fc3.in_orbit(*i));
+            assert_eq!(None, fc3.representative(*i));
+        }
+        for i in [2, 4, 6].iter() {
+            // Tests for fc1
+            assert!(!fc1.in_orbit(*i));
+            assert_eq!(None, fc1.representative(*i));
+            // Tests for fc2
+            assert!(fc2.in_orbit(*i));
+            assert_eq!(*i, fc2.representative(*i).unwrap().apply(4));
+            // Tests for fc3
+            assert!(!fc3.in_orbit(*i));
+            assert_eq!(None, fc3.representative(*i));
+        }
+        // Now to test for element 3
+        // Tests for fc1
+        assert!(!fc1.in_orbit(3));
+        assert_eq!(None, fc1.representative(3));
+        // Tests for fc2
+        assert!(!fc2.in_orbit(3));
+        assert_eq!(None, fc2.representative(3));
+        // Tests for fc3
+        assert!(fc3.in_orbit(3));
+        assert_eq!(3, fc3.representative(3).unwrap().apply(3));
+    }
 }

--- a/src/group/orbit/factored_transversal.rs
+++ b/src/group/orbit/factored_transversal.rs
@@ -62,10 +62,9 @@ impl FactoredTransversal {
     ///```
     /// use stabchain::group::orbit::factored_transversal::FactoredTransversal;
     /// use stabchain::perm::Permutation;
-    /// let fc = FactoredTransversal::from_generators(0, &[Permutation::from(vec![1, 0])]);
-    /// let rep = Permutation::from(vec![1, 0]);
-    /// assert_eq!(rep, fc.representative(1).unwrap());
-    /// assert_eq!(Permutation::id(), fc.representative(0).unwrap());
+    /// let fc = FactoredTransversal::from_generators(0, &[Permutation::from(vec![1, 0, 2])]);
+    /// assert_eq!(1, fc.representative(1).unwrap().apply(0));
+    /// assert_eq!(None, fc.representative(2));
     ///```
     pub fn representative(&self, delta: usize) -> Option<Permutation> {
         // Check if the element is in the orbit.

--- a/src/group/orbit/factored_transversal.rs
+++ b/src/group/orbit/factored_transversal.rs
@@ -196,6 +196,7 @@ mod tests {
     #[test]
     fn multiple_generators() {
         use crate::perm::export::CyclePermutation;
+        // Cycle notation is used for conveninece, but we do need to switch to 0 indexed for assertions.
         let gens: Vec<Permutation> = vec![
             CyclePermutation::from_vec(vec![vec![1, 6, 4, 3], vec![2, 7, 5]]).into(),
             CyclePermutation::from_vec(vec![vec![1, 4], vec![2, 6, 3]]).into(),
@@ -215,6 +216,7 @@ mod tests {
     #[test]
     fn multiple_generators_non_full_orbit() {
         use crate::perm::export::CyclePermutation;
+        // Cycle notation is used for conveninece, but we do need to switch to 0 indexed for assertions.
         let gens: Vec<Permutation> = vec![
             CyclePermutation::from_vec(vec![vec![1, 2, 6]]).into(),
             CyclePermutation::from_vec(vec![vec![3, 5, 7]]).into(),

--- a/src/group/orbit/factored_transversal.rs
+++ b/src/group/orbit/factored_transversal.rs
@@ -193,4 +193,21 @@ mod tests {
         //check orbit size
         assert_eq!(4, fc.len());
     }
+    /// Test the factored transversal calculation for a generating set with multiple generators.
+    #[test]
+    fn multiple_generators() {
+        use crate::perm::export::CyclePermutation;
+        let gens: Vec<Permutation> = vec![
+            CyclePermutation::from_vec(vec![vec![1, 6, 4, 3], vec![2, 7, 5]]).into(),
+            CyclePermutation::from_vec(vec![vec![1, 4], vec![2, 6, 3]]).into(),
+        ];
+        //All points should be in the orbit (according to GAP)
+        for i in 0_usize..6 {
+            let fc = FactoredTransversal::from_generators(i, &gens[..]);
+            for j in 0_usize..6 {
+                assert!(fc.in_orbit(j));
+                assert_eq!(j, fc.representative(j).unwrap().apply(i));
+            }
+        }
+    }
 }

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -317,10 +317,14 @@ mod tests {
         let perm2 = Permutation::from(vec![0, 2, 1]);
         let expected_perm = Permutation::from(vec![2, 0, 1]);
         assert_eq!(perm1.multiply(&perm2), expected_perm);
+        // Should not be the same when order is reveresed.
+        assert_ne!(perm2.multiply(&perm1), expected_perm);
         let perm1 = Permutation::from(vec![1, 2, 3, 0]);
         let perm2 = Permutation::from(vec![0, 2, 1]);
         let expected_perm = Permutation::from(vec![2, 1, 3, 0]);
-        assert_eq!(perm1.multiply(&perm2), expected_perm)
+        assert_eq!(perm1.multiply(&perm2), expected_perm);
+        // Should not be the same when order is reveresed.
+        assert_ne!(perm2.multiply(&perm1), expected_perm);
     }
 
     /// Check that the multiplication is associative

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -271,6 +271,7 @@ mod tests {
     #[test]
     fn not_eq_perm() {
         assert_ne!(Permutation::id(), Permutation::from_vec(vec![2, 1, 0]));
+        assert_ne!(Permutation::from_vec(vec![2, 1, 0]), Permutation::id());
     }
 
     #[test]
@@ -332,6 +333,41 @@ mod tests {
             perm1.multiply(&perm2),
             perm1.build_multiply(&perm2).collapse()
         )
+    }
+
+    /// Test inverse for the indentity.
+    #[test]
+    fn invert_perm_id() {
+        let id = Permutation::id();
+        assert_eq!(id, id.inv());
+        assert_eq!(id, id.inv().inv());
+    }
+    /// Test inverting permutation for normal cases.
+    #[test]
+    fn invert_perm() {
+        let id = Permutation::id();
+        //Permutation that is its own inverse
+        let perm1 = Permutation::from(vec![5, 4, 2, 6, 1, 0, 3]);
+        assert_eq!(perm1, perm1.inv());
+        assert_eq!(perm1.multiply(&perm1.inv()), id);
+        // n-cycle permutations
+        let perm2 = Permutation::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+        let perm2_inv = Permutation::from(vec![9, 0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_ne!(perm2, perm2_inv);
+        assert_eq!(perm2_inv, perm2.inv());
+        assert_eq!(perm2, perm2.inv().inv());
+        assert_eq!(perm2, perm2_inv.inv());
+        assert_eq!(perm2.multiply(&perm2_inv), id);
+        assert_eq!(perm2_inv.multiply(&perm2), id);
+        //Permutations with more than one cycle.
+        let perm3 = Permutation::from(vec![2, 5, 4, 6, 0, 3, 1]);
+        let perm3_inv = Permutation::from(vec![4, 6, 0, 5, 2, 1, 3]);
+        assert_ne!(perm3, perm3_inv);
+        assert_eq!(perm3_inv, perm3.inv());
+        assert_eq!(perm3, perm3.inv().inv());
+        assert_eq!(perm3, perm3_inv.inv());
+        assert_eq!(perm3.multiply(&perm3_inv), id);
+        assert_eq!(perm3_inv.multiply(&perm3), id);
     }
 
     #[test]

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -323,6 +323,18 @@ mod tests {
         assert_eq!(perm1.multiply(&perm2), expected_perm)
     }
 
+    /// Check that the multiplication is associative
+    #[test]
+    fn mult_perm_associative() {
+        let perm1 = Permutation::from(vec![1, 5, 4, 0, 2, 3]);
+        let perm2 = Permutation::from(vec![3, 2, 0, 1]);
+        let perm3 = Permutation::from(vec![6, 5, 4, 3, 2, 1, 0]);
+        assert_eq!(
+            perm1.multiply(&perm2).multiply(&perm3),
+            perm1.multiply(&perm2.multiply(&perm3))
+        );
+    }
+
     /// Test that multiplication for the lazy or eager implementaions are identical
     #[test]
     fn mult_perm_lazy_eager() {


### PR DESCRIPTION
I've written more tests for the basic permutation type and the factored transversal, including:

- Testing of inverse for permutations
- Checking associativity of permutation multiplication
- Testing the Factored Transversal for multi generator groups (previous tests only had a single generator)