### PR TITLE
Added and benchmarked impl for opt in orbit

### DIFF
--- a/benches/entry.rs
+++ b/benches/entry.rs
@@ -3,7 +3,7 @@ use criterion::criterion_main;
 mod group;
 mod perm;
 
-use group::orbit::orbit;
+use group::orbit::{orbit, orbit_impl};
 use perm::permutation;
 
-criterion_main!(permutation, orbit);
+criterion_main!(permutation, orbit, orbit_impl);

--- a/benches/entry.rs
+++ b/benches/entry.rs
@@ -3,7 +3,8 @@ use criterion::criterion_main;
 mod group;
 mod perm;
 
-use group::orbit::{orbit, orbit_impl};
+use group::orbit;
+use group::orbit::orbit_impl;
 use perm::permutation;
 
 criterion_main!(permutation, orbit, orbit_impl);

--- a/benches/group/mod.rs
+++ b/benches/group/mod.rs
@@ -1,1 +1,163 @@
 pub mod orbit;
+
+use criterion::{criterion_group, BenchmarkId, Criterion};
+const RANGE_OF_VALUES: [usize; 4] = [8, 16, 32, 64];
+use stabchain::group::Group;
+
+// Comparing different methods of obtaining an orbit ---------------------------
+
+fn orbit_vs_factored_symmetric(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_symmetric");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| g.orbit(0));
+        });
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| g.factored_transversal(0).orbit());
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| g.transversal(0).orbit());
+        });
+    }
+    group.finish();
+}
+
+fn orbit_vs_factored_dihedral(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_dihedral");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = Group::dihedral_2n(*i);
+            b.iter(|| g.orbit(0));
+        });
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::dihedral_2n(*i);
+            b.iter(|| g.factored_transversal(0).orbit());
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::dihedral_2n(*i);
+            b.iter(|| g.transversal(0).orbit());
+        });
+    }
+    group.finish();
+}
+
+fn orbit_vs_factored_cyclic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_cyclic");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = Group::cyclic(*i);
+            b.iter(|| g.orbit(0));
+        });
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::cyclic(*i);
+            b.iter(|| g.factored_transversal(0).orbit());
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::cyclic(*i);
+            b.iter(|| g.transversal(0).orbit());
+        });
+    }
+    group.finish();
+}
+
+// Comparing representative calculation ---------------------------
+
+fn transversal_vs_factored_symmetric(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_symmetric");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| {
+                let transversal = g.factored_transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| {
+                let transversal = g.transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_factored_dihedral(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_dihedral");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::dihedral_2n(*i);
+            b.iter(|| {
+                let transversal = g.factored_transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::dihedral_2n(*i);
+            b.iter(|| {
+                let transversal = g.transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_factored_cyclic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_cyclic");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
+            let g = Group::cyclic(*i);
+            b.iter(|| {
+                let transversal = g.factored_transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::cyclic(*i);
+            b.iter(|| {
+                let transversal = g.transversal(0);
+                let orbit = transversal.orbit().to_set().clone();
+                orbit
+                    .into_iter()
+                    .map(|i| transversal.representative(i))
+                    .collect::<Vec<_>>()
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    orbit,
+    orbit_vs_factored_symmetric,
+    orbit_vs_factored_dihedral,
+    orbit_vs_factored_cyclic,
+    transversal_vs_factored_symmetric,
+    transversal_vs_factored_dihedral,
+    transversal_vs_factored_cyclic,
+);

--- a/benches/group/orbit.rs
+++ b/benches/group/orbit.rs
@@ -4,6 +4,43 @@ const RANGE_OF_VALUES: [usize; 4] = [8, 16, 32, 64];
 
 use stabchain::group::Group;
 
+// Comparing orbit optimizations
+
+fn orbit_vs_optmized_orbit_complete(c: &mut Criterion) {
+    use stabchain::group::orbit::{orbit, orbit_complete_opt};
+
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_complete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| orbit(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("orbit_optmized", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| orbit_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+fn orbit_vs_optmized_orbit_uncomplete(c: &mut Criterion) {
+    use stabchain::group::orbit::{orbit, orbit_complete_opt};
+    use stabchain::group::utils::copies_of_cyclic;
+
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_uncomplete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| orbit(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("orbit_optmized", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| orbit_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
 // Comparing different methods of obtaining an orbit ---------------------------
 
 fn orbit_vs_factored_symmetric(c: &mut Criterion) {
@@ -151,6 +188,12 @@ fn transversal_vs_factored_cyclic(c: &mut Criterion) {
     }
     group.finish();
 }
+
+criterion_group!(
+    orbit_impl,
+    orbit_vs_optmized_orbit_complete,
+    orbit_vs_optmized_orbit_uncomplete,
+);
 
 criterion_group!(
     orbit,

--- a/benches/group/orbit.rs
+++ b/benches/group/orbit.rs
@@ -23,6 +23,23 @@ fn orbit_vs_optmized_orbit_complete(c: &mut Criterion) {
     group.finish();
 }
 
+fn orbit_vs_optmized_orbit_complete_many_generators(c: &mut Criterion) {
+    use stabchain::group::orbit::{orbit, orbit_complete_opt};
+
+    let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_complete_many_gens");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| orbit(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("orbit_optmized", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| orbit_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
 fn orbit_vs_optmized_orbit_uncomplete(c: &mut Criterion) {
     use stabchain::group::orbit::{orbit, orbit_complete_opt};
     use stabchain::group::utils::copies_of_cyclic;
@@ -41,166 +58,9 @@ fn orbit_vs_optmized_orbit_uncomplete(c: &mut Criterion) {
     group.finish();
 }
 
-// Comparing different methods of obtaining an orbit ---------------------------
-
-fn orbit_vs_factored_symmetric(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_symmetric");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
-            let g = Group::symmetric(*i);
-            b.iter(|| g.orbit(0));
-        });
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::symmetric(*i);
-            b.iter(|| g.factored_transversal(0).orbit());
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::symmetric(*i);
-            b.iter(|| g.transversal(0).orbit());
-        });
-    }
-    group.finish();
-}
-
-fn orbit_vs_factored_dihedral(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_dihedral");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
-            let g = Group::dihedral_2n(*i);
-            b.iter(|| g.orbit(0));
-        });
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::dihedral_2n(*i);
-            b.iter(|| g.factored_transversal(0).orbit());
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::dihedral_2n(*i);
-            b.iter(|| g.transversal(0).orbit());
-        });
-    }
-    group.finish();
-}
-
-fn orbit_vs_factored_cyclic(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__orbit_vs_factored_cyclic");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
-            let g = Group::cyclic(*i);
-            b.iter(|| g.orbit(0));
-        });
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::cyclic(*i);
-            b.iter(|| g.factored_transversal(0).orbit());
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::cyclic(*i);
-            b.iter(|| g.transversal(0).orbit());
-        });
-    }
-    group.finish();
-}
-
-// Comparing representative calculation ---------------------------
-
-fn transversal_vs_factored_symmetric(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_symmetric");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::symmetric(*i);
-            b.iter(|| {
-                let transversal = g.factored_transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::symmetric(*i);
-            b.iter(|| {
-                let transversal = g.transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-    }
-    group.finish();
-}
-
-fn transversal_vs_factored_dihedral(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_dihedral");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::dihedral_2n(*i);
-            b.iter(|| {
-                let transversal = g.factored_transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::dihedral_2n(*i);
-            b.iter(|| {
-                let transversal = g.transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-    }
-    group.finish();
-}
-
-fn transversal_vs_factored_cyclic(c: &mut Criterion) {
-    let mut group = c.benchmark_group("group__orbit__transversal_vs_factored_cyclic");
-    for i in RANGE_OF_VALUES.iter() {
-        group.bench_with_input(BenchmarkId::new("factored_transversal", i), i, |b, i| {
-            let g = Group::cyclic(*i);
-            b.iter(|| {
-                let transversal = g.factored_transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
-            let g = Group::cyclic(*i);
-            b.iter(|| {
-                let transversal = g.transversal(0);
-                let orbit = transversal.orbit().to_set().clone();
-                orbit
-                    .into_iter()
-                    .map(|i| transversal.representative(i))
-                    .collect::<Vec<_>>()
-            });
-        });
-    }
-    group.finish();
-}
-
 criterion_group!(
     orbit_impl,
     orbit_vs_optmized_orbit_complete,
     orbit_vs_optmized_orbit_uncomplete,
-);
-
-criterion_group!(
-    orbit,
-    orbit_vs_factored_symmetric,
-    orbit_vs_factored_dihedral,
-    orbit_vs_factored_cyclic,
-    transversal_vs_factored_symmetric,
-    transversal_vs_factored_dihedral,
-    transversal_vs_factored_cyclic,
+    orbit_vs_optmized_orbit_complete_many_generators
 );

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -43,6 +43,16 @@ impl Group {
         orbit::factored_transversal::FactoredTransversal::new(self, base)
     }
 
+    /// Computes the smallest n s.t. G <= S_n
+    pub fn symmetric_super_order(&self) -> usize {
+        self.generators
+            .iter()
+            .flat_map(|g| g.lmp())
+            .max()
+            .unwrap_or(0)
+            + 1
+    }
+
     /// Generates the trivial group, which only contains the identity
     pub fn trivial() -> Self {
         // TODO: Should we include the identity here?
@@ -127,5 +137,13 @@ mod tests {
     fn orbit_vs_factored_orbit() {
         let g = Group::symmetric(10);
         assert_eq!(g.orbit(0), g.factored_transversal(0).orbit())
+    }
+
+    #[test]
+    fn check_symmetric_super() {
+        assert_eq!(Group::trivial().symmetric_super_order(), 1);
+        assert_eq!(Group::symmetric(10).symmetric_super_order(), 10);
+        assert_eq!(Group::dihedral_2n(10).symmetric_super_order(), 20);
+        assert_eq!(Group::cyclic(15).symmetric_super_order(), 15);
     }
 }

--- a/src/group/orbit/mod.rs
+++ b/src/group/orbit/mod.rs
@@ -21,6 +21,13 @@ impl Orbit {
         }
     }
 
+    /// Is this a complete orbit?
+    pub fn complete(&self, g: &Group) -> bool {
+        // If subgroup of S_n can at most move n points, if we already have seen all of them
+        // the orbit must be complete
+        self.orbit.len() == g.symmetric_super_order()
+    }
+
     /// Get the base (w)
     pub fn base(&self) -> usize {
         self.base
@@ -75,6 +82,40 @@ pub fn orbit(g: &Group, w: usize) -> HashSet<usize> {
             let gamma = g.apply(delta);
             if orbit.insert(gamma) {
                 to_traverse.push_back(gamma);
+            }
+        }
+    }
+
+    orbit
+}
+
+/// Algorithm to compute orbit from a group. This variant optimizes by checking
+/// if the orbit is complete before doing more work
+pub fn orbit_complete_opt(g: &Group, w: usize) -> HashSet<usize> {
+    let maximal_orbit_size = g.symmetric_super_order();
+    let gens = g.generators();
+
+    // Orbit are the ones that have been acted on by the generators
+    let mut orbit = HashSet::new();
+    orbit.insert(w);
+
+    // To traverse are those still to be expanded
+    let mut to_traverse = VecDeque::new();
+    to_traverse.push_back(w);
+
+    // Get unused
+    while !to_traverse.is_empty() {
+        let delta = to_traverse.pop_front().unwrap();
+        for g in gens {
+            // Apply generator and insert
+            let gamma = g.apply(delta);
+            if orbit.insert(gamma) {
+                to_traverse.push_back(gamma);
+            }
+
+            // Check if the orbit complete, if so return
+            if orbit.len() == maximal_orbit_size {
+                return orbit;
             }
         }
     }


### PR DESCRIPTION
So I have added a parallel orbit implementation which, at the cost of one extra check, is able to determine whether the orbit is already complete, and so reduce the amount of needed work. I have added some benchmarks as well, with comparision in both a complete setting (such as S_n) (In which the new algorithm should dominate) and in a group which does not give rise to complete orbit (In which the old implementation should still be a bit more efficient). 