### PR TITLE
Random Permutation Generation Fix

### DIFF
--- a/src/group/random_perm.rs
+++ b/src/group/random_perm.rs
@@ -64,7 +64,7 @@ impl RandPerm {
             t = self.rng.gen_range(0, self.size);
         }
         // Either take product or quotient.
-        let e = self.rng.gen_range(-1, 2);
+        let e: usize = if self.rng.gen::<bool>() { 1 } else { -1 };
         // Randomly determine order of operation.
         // The operation works by replacing a list entry with a product, and then accumulating with the stored permutation.
         if self.rng.gen::<bool>() {


### PR DESCRIPTION
Will now only take product or division, no longer having the option for identity.