### PR TITLE
Added optimization for other orbit algorithm

### DIFF
--- a/benches/entry.rs
+++ b/benches/entry.rs
@@ -4,7 +4,15 @@ mod group;
 mod perm;
 
 use group::orbit;
-use group::orbit::orbit_impl;
+use group::orbit::{
+    factored_transversal::factored_transversal_impl, orbit_impl, transversal::transversal_impl,
+};
 use perm::permutation;
 
-criterion_main!(permutation, orbit, orbit_impl);
+criterion_main!(
+    permutation,
+    orbit,
+    orbit_impl,
+    transversal_impl,
+    factored_transversal_impl
+);

--- a/benches/group/orbit/factored_transversal.rs
+++ b/benches/group/orbit/factored_transversal.rs
@@ -1,0 +1,68 @@
+use criterion::{criterion_group, BenchmarkId, Criterion};
+
+const RANGE_OF_VALUES: [usize; 4] = [8, 16, 32, 64];
+
+use stabchain::group::orbit::factored_transversal::{
+    factored_transversal, factored_transversal_complete_opt,
+};
+use stabchain::group::Group;
+
+// Comparing orbit optimizations
+
+fn transversal_vs_optmized_transversal_complete(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("group__orbit__f_transversal_vs_optmized_f_transversal_complete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| factored_transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| factored_transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_optmized_transversal_complete_many_generators(c: &mut Criterion) {
+    let mut group = c.benchmark_group(
+        "group__orbit__f_transversal_vs_optmized_f_transversal_complete_many_gens",
+    );
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| factored_transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| factored_transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_optmized_transversal_uncomplete(c: &mut Criterion) {
+    use stabchain::group::utils::copies_of_cyclic;
+
+    let mut group =
+        c.benchmark_group("group__orbit__f_transversal_vs_optmized_f_transversal_uncomplete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| factored_transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| factored_transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    factored_transversal_impl,
+    transversal_vs_optmized_transversal_complete,
+    transversal_vs_optmized_transversal_complete_many_generators,
+    transversal_vs_optmized_transversal_uncomplete
+);

--- a/benches/group/orbit/mod.rs
+++ b/benches/group/orbit/mod.rs
@@ -1,14 +1,16 @@
+pub mod factored_transversal;
+pub mod transversal;
+
 use criterion::{criterion_group, BenchmarkId, Criterion};
 
 const RANGE_OF_VALUES: [usize; 4] = [8, 16, 32, 64];
 
+use stabchain::group::orbit::{orbit, orbit_complete_opt};
 use stabchain::group::Group;
 
 // Comparing orbit optimizations
 
 fn orbit_vs_optmized_orbit_complete(c: &mut Criterion) {
-    use stabchain::group::orbit::{orbit, orbit_complete_opt};
-
     let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_complete");
     for i in RANGE_OF_VALUES.iter() {
         group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
@@ -24,8 +26,6 @@ fn orbit_vs_optmized_orbit_complete(c: &mut Criterion) {
 }
 
 fn orbit_vs_optmized_orbit_complete_many_generators(c: &mut Criterion) {
-    use stabchain::group::orbit::{orbit, orbit_complete_opt};
-
     let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_complete_many_gens");
     for i in RANGE_OF_VALUES.iter() {
         group.bench_with_input(BenchmarkId::new("orbit", i), i, |b, i| {
@@ -41,7 +41,6 @@ fn orbit_vs_optmized_orbit_complete_many_generators(c: &mut Criterion) {
 }
 
 fn orbit_vs_optmized_orbit_uncomplete(c: &mut Criterion) {
-    use stabchain::group::orbit::{orbit, orbit_complete_opt};
     use stabchain::group::utils::copies_of_cyclic;
 
     let mut group = c.benchmark_group("group__orbit__orbit_vs_optmized_orbit_uncomplete");

--- a/benches/group/orbit/transversal.rs
+++ b/benches/group/orbit/transversal.rs
@@ -1,0 +1,64 @@
+use criterion::{criterion_group, BenchmarkId, Criterion};
+
+const RANGE_OF_VALUES: [usize; 4] = [8, 16, 32, 64];
+
+use stabchain::group::orbit::transversal::{transversal, transversal_complete_opt};
+use stabchain::group::Group;
+
+// Comparing orbit optimizations
+
+fn transversal_vs_optmized_transversal_complete(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group__orbit__transversal_vs_optmized_transversal_complete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = Group::symmetric(*i);
+            b.iter(|| transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_optmized_transversal_complete_many_generators(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("group__orbit__transversal_vs_optmized_transversal_complete_many_gens");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = Group::alternating(*i);
+            b.iter(|| transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+fn transversal_vs_optmized_transversal_uncomplete(c: &mut Criterion) {
+    use stabchain::group::utils::copies_of_cyclic;
+
+    let mut group =
+        c.benchmark_group("group__orbit__transversal_vs_optmized_transversal_uncomplete");
+    for i in RANGE_OF_VALUES.iter() {
+        group.bench_with_input(BenchmarkId::new("transversal", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| transversal(&g, 0));
+        });
+        group.bench_with_input(BenchmarkId::new("transversal_optmized", i), i, |b, i| {
+            let g = copies_of_cyclic(&[*i, 20, 20]);
+            b.iter(|| transversal_complete_opt(&g, 0));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    transversal_impl,
+    transversal_vs_optmized_transversal_complete,
+    transversal_vs_optmized_transversal_complete_many_generators,
+    transversal_vs_optmized_transversal_uncomplete
+);

--- a/src/group/orbit/transversal.rs
+++ b/src/group/orbit/transversal.rs
@@ -84,6 +84,43 @@ pub fn transversal(g: &Group, base: usize) -> HashMap<usize, Permutation> {
     transversal
 }
 
+/// Optimized version of transversal which does less work on complete groups
+// Needed since entry requires &mut
+#[allow(clippy::map_entry)]
+pub fn transversal_complete_opt(g: &Group, base: usize) -> HashMap<usize, Permutation> {
+    // Get the generatos
+    let gens = &g.generators[..];
+    let maximal_orbit_size = g.symmetric_super_order();
+    let mut transversal = HashMap::new();
+
+    // Init the transversal
+    transversal.insert(base, Permutation::id());
+
+    // We use this to store elements to expand
+    let mut to_traverse = VecDeque::new();
+    to_traverse.push_back(base);
+
+    // While we have stuff to do
+    while !to_traverse.is_empty() {
+        let delta = to_traverse.pop_front().unwrap();
+        for g in gens {
+            let gamma = g.apply(delta);
+
+            if !transversal.contains_key(&gamma) {
+                to_traverse.push_back(gamma);
+                let delta_repr = transversal.get(&delta).cloned().unwrap();
+                transversal.insert(gamma, delta_repr.multiply(g));
+            }
+
+            if transversal.len() == maximal_orbit_size {
+                return transversal;
+            }
+        }
+    }
+
+    transversal
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
So, I have made the same optimization as for orbit for the other two orbit based algorithms. 
I have included benchmarks (which I have not yet run, but I expect to see results similar to those in orbit). Also changed the factored transversal to have a function API as in orbit and transversal (makes it easier for benchmarking)