### PR TITLE
Fix from

### DIFF
--- a/src/perm/export/classic.rs
+++ b/src/perm/export/classic.rs
@@ -72,18 +72,18 @@ impl From<CyclePermutation> for ClassicalPermutation {
     }
 }
 
-impl From<ClassicalPermutation> for StandardPermutation {
-    fn from(perm: ClassicalPermutation) -> Self {
-        perm.0
-    }
-}
-
 impl<P> From<P> for ClassicalPermutation
 where
     P: Permutation,
 {
     fn from(p: P) -> Self {
         ClassicalPermutation(StandardPermutation::from_images(&p.images()[..]))
+    }
+}
+
+impl From<ClassicalPermutation> for StandardPermutation {
+    fn from(perm: ClassicalPermutation) -> Self {
+        perm.0
     }
 }
 

--- a/src/perm/export/classic.rs
+++ b/src/perm/export/classic.rs
@@ -43,12 +43,6 @@ impl ClassicalPermutation {
     }
 }
 
-impl From<StandardPermutation> for ClassicalPermutation {
-    fn from(perm: StandardPermutation) -> Self {
-        ClassicalPermutation(perm)
-    }
-}
-
 impl From<CyclePermutation> for ClassicalPermutation {
     fn from(perm: CyclePermutation) -> Self {
         let cycles = perm.cycles();
@@ -83,6 +77,42 @@ impl From<ClassicalPermutation> for StandardPermutation {
         perm.0
     }
 }
+
+impl<P> From<P> for ClassicalPermutation
+where
+    P: Permutation,
+{
+    fn from(p: P) -> Self {
+        ClassicalPermutation(StandardPermutation::from_images(&p.images()[..]))
+    }
+}
+
+macro_rules! impl_from_for_perm {
+    ($name:ty) => {
+        impl From<ClassicalPermutation> for $name {
+            fn from(perm: ClassicalPermutation) -> Self {
+                <$name>::from_images(perm.0.as_vec())
+            }
+        }
+    };
+}
+
+macro_rules! impl_all {
+    ($($name:ty), *) => {
+        $(impl_from_for_perm!($name);)*
+    };
+}
+
+use crate::perm::impls::{
+    based::BasedPermutation, map::MapPermutation, sync::SyncPermutation, word::WordPermutation,
+};
+
+impl_all!(
+    BasedPermutation,
+    MapPermutation,
+    SyncPermutation,
+    WordPermutation
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/perm/export/cycles.rs
+++ b/src/perm/export/cycles.rs
@@ -1,8 +1,4 @@
 use super::ClassicalPermutation;
-use crate::perm::impls::{
-    based::BasedPermutation, map::MapPermutation, standard::StandardPermutation,
-    sync::SyncPermutation,
-};
 use crate::perm::Permutation;
 use serde::{Deserialize, Serialize};
 
@@ -69,36 +65,12 @@ impl CyclePermutation {
     }
 }
 
-impl From<StandardPermutation> for CyclePermutation {
-    fn from(perm: StandardPermutation) -> Self {
+impl<P> From<P> for CyclePermutation
+where
+    P: Permutation,
+{
+    fn from(perm: P) -> Self {
         CyclePermutation::from(ClassicalPermutation::from(perm))
-    }
-}
-
-impl From<SyncPermutation> for CyclePermutation {
-    fn from(perm: SyncPermutation) -> Self {
-        CyclePermutation::from(StandardPermutation::from(perm))
-    }
-}
-
-impl From<CyclePermutation> for StandardPermutation {
-    fn from(perm: CyclePermutation) -> Self {
-        let int: ClassicalPermutation = perm.into();
-        int.into()
-    }
-}
-
-impl From<CyclePermutation> for BasedPermutation {
-    fn from(perm: CyclePermutation) -> Self {
-        let int: StandardPermutation = perm.into();
-        int.into()
-    }
-}
-
-impl From<CyclePermutation> for MapPermutation {
-    fn from(perm: CyclePermutation) -> Self {
-        let int: StandardPermutation = perm.into();
-        int.into()
     }
 }
 
@@ -163,6 +135,36 @@ impl From<ClassicalPermutation> for CyclePermutation {
         CyclePermutation::from_vec_unchecked(cycles)
     }
 }
+
+macro_rules! impl_from_for_perm {
+    ($name:ty) => {
+        impl From<CyclePermutation> for $name {
+            fn from(perm: CyclePermutation) -> Self {
+                let int: ClassicalPermutation = perm.into();
+                <$name>::from(int)
+            }
+        }
+    };
+}
+
+macro_rules! impl_all {
+    ($($name:ty), *) => {
+        $(impl_from_for_perm!($name);)*
+    };
+}
+
+use crate::perm::impls::{
+    based::BasedPermutation, map::MapPermutation, standard::StandardPermutation,
+    sync::SyncPermutation, word::WordPermutation,
+};
+
+impl_all!(
+    StandardPermutation,
+    SyncPermutation,
+    MapPermutation,
+    BasedPermutation,
+    WordPermutation
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/perm/export/mod.rs
+++ b/src/perm/export/mod.rs
@@ -7,15 +7,24 @@ pub use classic::ClassicalPermutation;
 pub use cycles::CyclePermutation;
 
 use super::impls::standard::StandardPermutation;
-use super::impls::sync::SyncPermutation;
+use crate::perm::Permutation;
 
 /// A permutation that is easy to export
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportablePermutation(Vec<usize>);
 
-impl From<StandardPermutation> for ExportablePermutation {
-    fn from(perm: StandardPermutation) -> Self {
-        ClassicalPermutation::from(perm).into()
+impl<P> From<P> for ExportablePermutation
+where
+    P: Permutation,
+{
+    fn from(perm: P) -> Self {
+        ClassicalPermutation::from(StandardPermutation::from_images(&perm.images()[..])).into()
+    }
+}
+
+impl From<ClassicalPermutation> for ExportablePermutation {
+    fn from(perm: ClassicalPermutation) -> Self {
+        ExportablePermutation(perm.images())
     }
 }
 
@@ -23,23 +32,5 @@ impl From<ExportablePermutation> for StandardPermutation {
     fn from(perm: ExportablePermutation) -> Self {
         use std::iter::FromIterator;
         StandardPermutation::from_iter(perm.0.iter().map(|i| i - 1))
-    }
-}
-
-impl From<SyncPermutation> for ExportablePermutation {
-    fn from(perm: SyncPermutation) -> Self {
-        StandardPermutation::from(perm).into()
-    }
-}
-
-impl From<ExportablePermutation> for SyncPermutation {
-    fn from(perm: ExportablePermutation) -> Self {
-        StandardPermutation::from(perm).into()
-    }
-}
-
-impl From<ClassicalPermutation> for ExportablePermutation {
-    fn from(perm: ClassicalPermutation) -> Self {
-        ExportablePermutation(perm.images())
     }
 }

--- a/src/perm/impls/based.rs
+++ b/src/perm/impls/based.rs
@@ -146,25 +146,3 @@ impl std::hash::Hash for BasedPermutation {
         self.perm.hash(state);
     }
 }
-
-impl From<StandardPermutation> for BasedPermutation {
-    fn from(perm: StandardPermutation) -> Self {
-        BasedPermutation::from_images(perm.as_vec())
-    }
-}
-
-impl From<BasedPermutation> for StandardPermutation {
-    fn from(perm: BasedPermutation) -> Self {
-        let images = (0..perm.base)
-            .chain(perm.perm.as_vec().iter().map(|i| i + perm.base))
-            .collect();
-        StandardPermutation::from_vec(images)
-    }
-}
-
-use std::fmt;
-impl fmt::Display for BasedPermutation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", StandardPermutation::from(self.clone()))
-    }
-}

--- a/src/perm/impls/map.rs
+++ b/src/perm/impls/map.rs
@@ -78,29 +78,3 @@ impl FromIterator<(usize, usize)> for MapPermutation {
         }
     }
 }
-
-use crate::perm::impls::standard::StandardPermutation;
-impl From<StandardPermutation> for MapPermutation {
-    fn from(perm: StandardPermutation) -> Self {
-        MapPermutation::from_images(perm.as_vec())
-    }
-}
-
-impl From<MapPermutation> for StandardPermutation {
-    fn from(perm: MapPermutation) -> Self {
-        let lmp = perm.lmp();
-        if lmp.is_none() {
-            return StandardPermutation::id();
-        }
-
-        let lmp = lmp.unwrap();
-        StandardPermutation::from_iter((0..=lmp).map(|i| perm.apply(i)))
-    }
-}
-
-use std::fmt;
-impl fmt::Display for MapPermutation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", StandardPermutation::from(self.clone()))
-    }
-}

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -2,7 +2,6 @@ use crate::perm::Permutation;
 
 use std::cell::RefCell;
 use std::cmp::max;
-use std::fmt;
 use std::iter::FromIterator;
 use std::rc::Rc;
 
@@ -127,13 +126,6 @@ impl Permutation for StandardPermutation {
         let new_images = self.vals.iter().map(|i| i + k);
         images.extend(new_images);
         StandardPermutation::from_vec_unchecked(images)
-    }
-}
-
-impl fmt::Display for StandardPermutation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use crate::perm::export::CyclePermutation;
-        write!(f, "{}", CyclePermutation::from(self.clone()))
     }
 }
 

--- a/src/perm/impls/sync.rs
+++ b/src/perm/impls/sync.rs
@@ -1,7 +1,6 @@
 use crate::perm::Permutation;
 
 use std::cmp::max;
-use std::fmt;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
@@ -110,13 +109,6 @@ impl Permutation for SyncPermutation {
         let new_images = self.0.vals.iter().map(|i| i + k);
         images.extend(new_images);
         SyncPermutation::from_vec_unchecked(images)
-    }
-}
-
-impl fmt::Display for SyncPermutation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use crate::perm::export::CyclePermutation;
-        write!(f, "{}", CyclePermutation::from(self.clone()))
     }
 }
 

--- a/src/perm/impls/sync.rs
+++ b/src/perm/impls/sync.rs
@@ -142,8 +142,8 @@ impl std::hash::Hash for SyncPermutation {
 
 impl From<StandardPermutation> for SyncPermutation {
     fn from(p: StandardPermutation) -> Self {
-        let vals = p.as_vec().to_vec();
-        let invvals = p.inv().as_vec().to_vec();
+        let vals = p.images();
+        let invvals = p.inv().images();
 
         SyncPermutation(Arc::new(SyncPermutationInner { vals, invvals }))
     }

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -20,6 +20,13 @@ pub trait Permutation: Clone + Eq + Hash {
     /// Given some images, build a permutation
     fn from_images(images: &[usize]) -> Self;
 
+    /// Get the images of the permutation
+    fn images(&self) -> Vec<usize> {
+        self.lmp()
+            .map(|n| (0..=n).map(|i| self.apply(i)).collect())
+            .unwrap_or_else(Vec::new)
+    }
+
     /// Get the identity
     fn id() -> Self;
 
@@ -59,13 +66,6 @@ pub trait Permutation: Clone + Eq + Hash {
     /// Computes self * other^-1
     fn divide(&self, other: &Self) -> Self {
         self.multiply(&other.inv())
-    }
-
-    /// Get the images of the permutation
-    fn images(&self) -> Vec<usize> {
-        self.lmp()
-            .map(|n| (0..=n).map(|i| self.apply(i)).collect())
-            .unwrap_or_else(Vec::new)
     }
 
     /// Get the smallest moved point

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -101,7 +101,7 @@ macro_rules! impl_display {
 }
 
 macro_rules! impl_all {
-    ($first:ty, $($other:ty, )*) => {
+    ([$first:ty], $($other:ty, )*) => {
         $(impl_conversions!($first, $other);)*
         impl_display!($first);
     };
@@ -113,14 +113,14 @@ use crate::perm::impls::{
 };
 
 impl_all!(
-    StandardPermutation,
+    [StandardPermutation],
     BasedPermutation,
     MapPermutation,
     WordPermutation,
 );
 
 impl_all!(
-    BasedPermutation,
+    [BasedPermutation],
     StandardPermutation,
     MapPermutation,
     SyncPermutation,
@@ -128,7 +128,7 @@ impl_all!(
 );
 
 impl_all!(
-    MapPermutation,
+    [MapPermutation],
     BasedPermutation,
     StandardPermutation,
     SyncPermutation,
@@ -136,14 +136,14 @@ impl_all!(
 );
 
 impl_all!(
-    SyncPermutation,
+    [SyncPermutation],
     MapPermutation,
     BasedPermutation,
     WordPermutation,
 );
 
 impl_all!(
-    WordPermutation,
+    [WordPermutation],
     SyncPermutation,
     MapPermutation,
     BasedPermutation,

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -56,8 +56,16 @@ pub trait Permutation: Clone + Eq + Hash {
         counter
     }
 
+    /// Computes self * other^-1
     fn divide(&self, other: &Self) -> Self {
         self.multiply(&other.inv())
+    }
+
+    /// Get the images of the permutation
+    fn images(&self) -> Vec<usize> {
+        self.lmp()
+            .map(|n| (0..=n).map(|i| self.apply(i)).collect())
+            .unwrap_or_else(Vec::new)
     }
 
     /// Get the smallest moved point

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -78,3 +78,74 @@ pub trait Action<P>: Default + Clone {
 
     fn apply(&self, p: &P, input: Self::OrbitT) -> Self::OrbitT;
 }
+
+macro_rules! impl_conversions {
+    ($first:ty, $second:ty) => {
+        impl From<$first> for $second {
+            fn from(p: $first) -> Self {
+                <$second>::from_images(&p.images()[..])
+            }
+        }
+    };
+}
+
+macro_rules! impl_display {
+    ($perm:ty) => {
+        impl std::fmt::Display for $perm {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                use crate::perm::export::CyclePermutation;
+                write!(f, "{}", CyclePermutation::from(self.clone()))
+            }
+        }
+    };
+}
+
+macro_rules! impl_all {
+    ($first:ty, $($other:ty, )*) => {
+        $(impl_conversions!($first, $other);)*
+        impl_display!($first);
+    };
+}
+
+use crate::perm::impls::{
+    based::BasedPermutation, map::MapPermutation, standard::StandardPermutation,
+    sync::SyncPermutation, word::WordPermutation,
+};
+
+impl_all!(
+    StandardPermutation,
+    BasedPermutation,
+    MapPermutation,
+    WordPermutation,
+);
+
+impl_all!(
+    BasedPermutation,
+    StandardPermutation,
+    MapPermutation,
+    SyncPermutation,
+    WordPermutation,
+);
+
+impl_all!(
+    MapPermutation,
+    BasedPermutation,
+    StandardPermutation,
+    SyncPermutation,
+    WordPermutation,
+);
+
+impl_all!(
+    SyncPermutation,
+    MapPermutation,
+    BasedPermutation,
+    WordPermutation,
+);
+
+impl_all!(
+    WordPermutation,
+    SyncPermutation,
+    MapPermutation,
+    BasedPermutation,
+    StandardPermutation,
+);


### PR DESCRIPTION
So, I had noticed that we had a lot of from conversions and the like floating about. I collected most of them with a blanket trait, and where rust's orphan trait forbids us I have added macros to derive all of it. In effect, now you can map each permutation type to each other one. Also each type will have Display implemented and can be easily converted to an exportable type