### PR TITLE
Fix bug in order multiplication

### DIFF
--- a/benches/perm/mod.rs
+++ b/benches/perm/mod.rs
@@ -85,7 +85,7 @@ fn exponentiation_small_exponent(c: &mut Criterion) {
 
 fn order_efficiency(c: &mut Criterion) {
     let mut group = c.benchmark_group("permutation__order_cmp");
-    for i in RANGE_OF_VALUES.iter() {
+    for i in [8, 16, 32, 64, 100].iter() {
         group.bench_with_input(BenchmarkId::new("default", i), i, |b, i| {
             let perm = random_permutation::<DefaultPermutation>(*i);
             b.iter(|| perm.order())

--- a/benches/perm/mod.rs
+++ b/benches/perm/mod.rs
@@ -91,26 +91,14 @@ fn order_efficiency(c: &mut Criterion) {
             b.iter(|| perm.order())
         });
         group.bench_with_input(BenchmarkId::new("iterated_mult", i), i, |b, i| {
+            use crate::perm::algos::order_mult;
             let perm = random_permutation::<DefaultPermutation>(*i);
-            b.iter(|| {
-                let mut acc = perm.clone();
-                let mut order = 1;
-                while !acc.is_id() {
-                    acc = acc.multiply(&perm);
-                    order += 1;
-                }
-                order
-            })
+            b.iter(|| order_mult(&perm))
         });
         group.bench_with_input(BenchmarkId::new("cycle", i), i, |b, i| {
+            use crate::perm::algos::order_cycle;
             let perm = random_permutation::<DefaultPermutation>(*i);
-            b.iter(|| {
-                use stabchain::perm::export::CyclePermutation;
-                let mut images = perm.images();
-                images.iter_mut().for_each(|i| *i += 1);
-                let cycle = CyclePermutation::from_images(&images[..]);
-                cycle.order()
-            })
+            b.iter(|| order_cycle(&perm))
         });
     }
     group.finish();

--- a/src/perm/algos.rs
+++ b/src/perm/algos.rs
@@ -1,4 +1,5 @@
 use super::impls::standard::StandardPermutation;
+use crate::perm::Permutation;
 
 /// The implementation of inverse, to be used mostly for benchmarking
 pub fn inv(p: &StandardPermutation) -> StandardPermutation {
@@ -13,4 +14,22 @@ pub(super) fn inv_unchecked(vals: &[usize]) -> Vec<usize> {
         v[vals[i]] = i;
     }
     v
+}
+
+pub fn order_mult(p: &impl Permutation) -> usize {
+    let mut acc = p.clone();
+    let mut counter = 1;
+    while !acc.is_id() {
+        acc = acc.multiply(p);
+        counter += 1;
+    }
+    counter
+}
+
+pub fn order_cycle(p: &impl Permutation) -> usize {
+    use crate::perm::export::CyclePermutation;
+    let mut images = p.images();
+    images.iter_mut().for_each(|i| *i += 1);
+    let cycle = CyclePermutation::from_images(&images[..]);
+    cycle.order()
 }

--- a/src/perm/export/cycles.rs
+++ b/src/perm/export/cycles.rs
@@ -17,6 +17,14 @@ impl CyclePermutation {
         CyclePermutation::from_vec(Vec::new())
     }
 
+    /// Take some images in the 1..=n range and output a cycled repr
+    pub fn from_images(images: &[usize]) -> Self {
+        assert!(images.iter().all(|&n| n > 0));
+
+        let classic = ClassicalPermutation::from_slice(images);
+        classic.into()
+    }
+
     pub fn from_vec(cycles: Vec<Vec<usize>>) -> Self {
         use std::collections::HashMap;
         // Check the element range

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -121,6 +121,12 @@ impl Permutation for StandardPermutation {
         images.extend(new_images);
         StandardPermutation::from_vec_unchecked(images)
     }
+
+    fn order(&self) -> usize {
+        use crate::perm::export::CyclePermutation;
+        let cycle = CyclePermutation::from(self.clone());
+        cycle.order()
+    }
 }
 
 impl PartialEq for StandardPermutation {

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -103,12 +103,6 @@ impl Permutation for StandardPermutation {
         }
     }
 
-    fn order(&self) -> usize {
-        // TODO: If we ever use order in resource heavy context, optmize here
-        use crate::perm::export::CyclePermutation;
-        CyclePermutation::from(self.clone()).order()
-    }
-
     fn lmp(&self) -> Option<usize> {
         if self.vals.is_empty() {
             None

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -121,12 +121,6 @@ impl Permutation for StandardPermutation {
         images.extend(new_images);
         StandardPermutation::from_vec_unchecked(images)
     }
-
-    fn order(&self) -> usize {
-        use crate::perm::export::CyclePermutation;
-        let cycle = CyclePermutation::from(self.clone());
-        cycle.order()
-    }
 }
 
 impl PartialEq for StandardPermutation {

--- a/src/perm/impls/sync.rs
+++ b/src/perm/impls/sync.rs
@@ -85,12 +85,6 @@ impl Permutation for SyncPermutation {
         }
     }
 
-    fn order(&self) -> usize {
-        // TODO: If we ever use order in resource heavy context, optmize here
-        use crate::perm::export::CyclePermutation;
-        CyclePermutation::from(self.clone()).order()
-    }
-
     fn lmp(&self) -> Option<usize> {
         if self.vals.is_empty() {
             None

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -11,6 +11,9 @@ pub mod utils;
 
 use std::hash::Hash;
 
+// Very much arbitrary
+const ORDER_LIMIT: usize = 12;
+
 /// The DefaultPermutation type. It is the permutation that, trough our testing,
 /// seems to perform better
 pub type DefaultPermutation = impls::standard::StandardPermutation;
@@ -54,13 +57,11 @@ pub trait Permutation: Clone + Eq + Hash {
 
     /// Get the order of the permutation
     fn order(&self) -> usize {
-        let mut acc = self.clone();
-        let mut counter = 1;
-        while !acc.is_id() {
-            acc = acc.multiply(self);
-            counter += 1;
+        match self.lmp() {
+            Some(n) if n <= ORDER_LIMIT => algos::order_mult(self),
+            Some(_) => algos::order_cycle(self),
+            None => 1,
         }
-        counter
     }
 
     /// Computes self * other^-1

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -54,8 +54,8 @@ pub trait Permutation: Clone + Eq + Hash {
 
     /// Get the order of the permutation
     fn order(&self) -> usize {
-        let mut acc = Self::id();
-        let mut counter = 0;
+        let mut acc = self.clone();
+        let mut counter = 1;
         while !acc.is_id() {
             acc = acc.multiply(self);
             counter += 1;

--- a/src/perm/utils.rs
+++ b/src/perm/utils.rs
@@ -20,6 +20,7 @@ pub fn random_permutation<P: Permutation>(n: usize) -> P {
 pub fn order_n_permutation<P: Permutation>(start: usize, n: usize) -> P {
     assert!(n > 0);
     assert!(start > 0);
+
     let cycle = CyclePermutation::from_vec(vec![(start..(start + n)).collect()]);
     let standard = StandardPermutation::from(cycle);
     let images = standard.as_vec();


### PR DESCRIPTION
Pretty much what the title says. Converting to cycle and computing lmp while clever is much slower than just multiplying. 