### PR TITLE
Random stabiliser chain preliminary optimisations

### DIFF
--- a/benches/group/stabilizer_chain/mod.rs
+++ b/benches/group/stabilizer_chain/mod.rs
@@ -2,8 +2,10 @@ pub mod selector;
 
 use criterion::{criterion_group, BenchmarkId, Criterion};
 const RANGE_OF_VALUES: [usize; 5] = [8, 10, 16, 20, 32];
-use stabchain::group::stabchain::builder::{IFTBuilderStrategy, NaiveBuilderStrategy};
-use stabchain::group::stabchain::moved_point_selector::DefaultSelector;
+use stabchain::group::stabchain::builder::{
+    IFTBuilderStrategy, NaiveBuilderStrategy, RandomBuilderStrategy,
+};
+use stabchain::group::stabchain::moved_point_selector::{DefaultSelector, FmpSelector};
 use stabchain::group::Group;
 use stabchain::perm::actions::SimpleApplication;
 
@@ -39,14 +41,13 @@ fn stabchain_cyclic(c: &mut Criterion) {
             (|i: &usize| Group::cyclic(*i)),
             IFTBuilderStrategy::new(SimpleApplication::default(), DefaultSelector::default())
         );
-        //TODO add back in when this has been optimised.
-        // bench_stabchain_impl!(
-        //     group,
-        //     "random",
-        //     i,
-        //     (|i: &usize| Group::cyclic(*i)),
-        //     RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
-        // );
+        bench_stabchain_impl!(
+            group,
+            "random",
+            i,
+            (|i: &usize| Group::cyclic(*i)),
+            RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
+        );
     }
     group.finish();
 }
@@ -72,13 +73,13 @@ fn stabchain_symmetric(c: &mut Criterion) {
             (|i: &usize| Group::symmetric(*i)),
             IFTBuilderStrategy::new(SimpleApplication::default(), DefaultSelector::default())
         );
-        // bench_stabchain_impl!(
-        //     group,
-        //     "random",
-        //     i,
-        //     (|i: &usize| Group::symmetric(*i)),
-        //     RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
-        // );
+        bench_stabchain_impl!(
+            group,
+            "random",
+            i,
+            (|i: &usize| Group::symmetric(*i)),
+            RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
+        );
     }
     group.finish();
 }
@@ -104,13 +105,13 @@ fn stabchain_direct_product_symm(c: &mut Criterion) {
             (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
             IFTBuilderStrategy::new(SimpleApplication::default(), DefaultSelector::default())
         );
-        // bench_stabchain_impl!(
-        //     group,
-        //     "random",
-        //     i,
-        //     (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
-        //     RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
-        // );
+        bench_stabchain_impl!(
+            group,
+            "random",
+            i,
+            (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
+            RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
+        );
     }
     group.finish();
 }

--- a/benches/group/stabilizer_chain/mod.rs
+++ b/benches/group/stabilizer_chain/mod.rs
@@ -105,13 +105,14 @@ fn stabchain_direct_product_symm(c: &mut Criterion) {
             (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
             IFTBuilderStrategy::new(SimpleApplication::default(), DefaultSelector::default())
         );
-        bench_stabchain_impl!(
-            group,
-            "random",
-            i,
-            (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
-            RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
-        );
+        //TODO comment once performance has improved.
+        // bench_stabchain_impl!(
+        //     group,
+        //     "random",
+        //     i,
+        //     (|i: &usize| Group::product(&Group::symmetric(*i), &Group::symmetric(*i))),
+        //     RandomBuilderStrategy::new(SimpleApplication::default(), FmpSelector::default())
+        // );
     }
     group.finish();
 }

--- a/src/group/stabchain/builder/random.rs
+++ b/src/group/stabchain/builder/random.rs
@@ -415,28 +415,3 @@ where
         self.build()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::group::stabchain::moved_point_selector::FmpSelector;
-    use crate::group::stabchain::valid_stabchain;
-    use crate::perm::actions::SimpleApplication;
-    use std::time::Instant;
-    #[test]
-    fn test() {
-        let g = Group::symmetric(20);
-        let application = SimpleApplication::default();
-        let mut builder = StabchainBuilderRandom::new(FmpSelector::default(), application);
-        let start = Instant::now();
-        builder.construct_strong_generating_set(&g);
-        let chain = builder.build();
-        let time = start.elapsed();
-        valid_stabchain(&chain).unwrap();
-        println!("time={}ms", time.as_millis());
-        assert_eq!(
-            num_bigint::BigUint::from(2432902008176640000_u128),
-            chain.order()
-        );
-    }
-}

--- a/src/group/stabchain/builder/random.rs
+++ b/src/group/stabchain/builder/random.rs
@@ -365,6 +365,7 @@ where
                 let initial_record = StabchainRecord::new(moved_point, gens, transversal);
                 self.base.push(moved_point);
                 self.chain.push(initial_record);
+                self.up_to_date = self.base.len() + 1;
                 return Some(self.current_pos + drop_out_level);
             } else {
                 //Otherwise add it to the generators at that level, and invoke the SGC at that level.

--- a/src/group/stabchain/builder/random.rs
+++ b/src/group/stabchain/builder/random.rs
@@ -366,10 +366,10 @@ where
                 self.base.push(moved_point);
                 self.chain.push(initial_record);
                 self.up_to_date = self.base.len() + 1;
-                return Some(self.current_pos + drop_out_level);
             } else {
                 //Otherwise add it to the generators at that level, and invoke the SGC at that level.
                 self.check_transversal_augmentation_at_level(invoke_level, collapsed_residue);
+                self.up_to_date = self.current_pos + drop_out_level + 1
             }
             Some(self.current_pos + drop_out_level)
         } else {

--- a/src/group/stabchain/builder/random.rs
+++ b/src/group/stabchain/builder/random.rs
@@ -124,7 +124,6 @@ where
             .map(|record| (record.transversal.len() as f64).log2())
             .sum::<f64>()
             .floor() as usize;
-        dbg!(&t);
         let record = &self.chain[self.current_pos];
         let k = rand::Rng::gen_range(&mut self.rng.clone(), 0, 1 + gens.len() / 2);
         //Create an iterator of subproducts w and w2
@@ -225,7 +224,6 @@ where
     }
 
     fn sgc(&mut self) {
-        dbg!("SGC");
         let record = self.chain[self.current_pos].clone();
         //Number of base points than are in the current orbit.
         let b_star = self
@@ -241,7 +239,6 @@ where
             .collect::<Vec<P>>();
         //Random products of the form gw
         let mut random_gens = self.random_schrier_generators_as_word(C1, C2, &gens[..]);
-        dbg!(random_gens.len());
         //Convert these into random schrier generators, by concatenating the resdiue of the inverse to it.
         random_gens.iter_mut().for_each(|gw| {
             //Get the residue of this word
@@ -322,7 +319,6 @@ where
 
     /// Test that the current strong generating set is indeed a strong generating set, returning true if it (probably) is.
     fn sgt(&mut self) {
-        dbg!("SGT");
         let original_position = self.current_pos;
         //Should be at the top of the chain, I think.
         self.current_pos = 0;

--- a/src/group/stabchain/builder/random.rs
+++ b/src/group/stabchain/builder/random.rs
@@ -136,6 +136,7 @@ where
         //Iterleave the two iterators.
         let subproduct_iter: Vec<Vec<P>> =
             subproduct_w1_iter.interleave(subproduct_w2_iter).collect();
+        //TODO check if precalculating all transversal elements would be faster.
         // Iterator of random coset representatives.
         let g_iter = repeat_with(|| {
             record


### PR DESCRIPTION
I've made some initial optimisations, mostly based on reducing the amount of wasted effort. This was done in two ways:

- Fixing the SGC being called after the SGT had already passed
- Reducing the parameters drastically

With the second point it was often the case that it was generating thousands of elements for even small groups, so they have been reduced a large amount. This hasn't affected this proportion of tests that successfully pass, but has sped up the randomised version dramatically. It is still slower than the deterministic version in all cases, but it is much closer now.

After optimisations, the flamegraphs showed the the stripping was taking the bulk of the time, so this is where optimisations should be focused. The part of the stripping taking longest was the representative calculation, and so it is likely that changing to shallow Shrier trees will give a speedup. This would further reduce the number of random elements to generate, as I've had to go with a rather loose upper bound, but this can be tightened if we have a guarantee on the depth of the trees.