### PR TITLE
Better API for Partial Fixed Base

### DIFF
--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -7,6 +7,8 @@ pub mod random_perm;
 pub mod stabchain;
 pub mod utils;
 
+use self::stabchain::base::selectors::adaptors::PartialFixedBaseSelector;
+use self::stabchain::base::selectors::DefaultSelector;
 use self::stabchain::base::selectors::FixedBaseSelector;
 use self::stabchain::builder::DefaultStrategy;
 use crate::group::orbit::abstraction::TransversalResolver;
@@ -213,7 +215,6 @@ where
     /// Computes a stabilizer chain for this group
     #[tracing::instrument]
     pub fn stabchain(&self) -> stabchain::Stabchain<P, impl TransversalResolver<P>> {
-        use self::stabchain::base::selectors::DefaultSelector;
         stabchain::Stabchain::new_with_strategy(
             self,
             DefaultStrategy::new(SimpleApplication::default(), DefaultSelector::default()),
@@ -229,6 +230,19 @@ where
         stabchain::Stabchain::new_with_strategy(
             self,
             DefaultStrategy::new(SimpleApplication::default(), FixedBaseSelector::new(base)),
+        )
+    }
+    /// Computes a stabilizer chain for this group with a partial base, using the default strategy for further points.
+    pub fn stabchain_partial_base(
+        &self,
+        partial_base: &[usize],
+    ) -> stabchain::Stabchain<P, impl TransversalResolver<P>> {
+        stabchain::Stabchain::new_with_strategy(
+            self,
+            DefaultStrategy::new(
+                SimpleApplication::default(),
+                PartialFixedBaseSelector::new(partial_base, DefaultSelector::default()),
+            ),
         )
     }
 

--- a/src/group/stabchain/base/selectors/adaptors.rs
+++ b/src/group/stabchain/base/selectors/adaptors.rs
@@ -120,4 +120,28 @@ mod tests {
             assert_eq!(selector.moved_point(&perm, i), perm.lmp().unwrap());
         }
     }
+
+    #[test]
+    fn partial_fixed_base_lmp() {
+        use super::super::LmpSelector;
+        use crate::group::Group;
+
+        use crate::perm::*;
+
+        let base = [0, 1, 2, 3, 4, 5];
+
+        let mut selector = PartialFixedBaseSelector::new(&base, LmpSelector::default());
+
+        let g = Group::symmetric(10);
+        let mut rand = g.rng();
+        for (i, perm) in (0..6).zip(std::iter::repeat_with(|| rand.random_permutation())) {
+            assert_eq!(selector.moved_point(&perm, i), i);
+        }
+
+        for (i, perm) in
+            (6..20).zip(std::iter::repeat_with(|| rand.random_permutation()).filter(|p| !p.is_id()))
+        {
+            assert_eq!(selector.moved_point(&perm, i), perm.lmp().unwrap());
+        }
+    }
 }

--- a/src/group/stabchain/base/selectors/adaptors.rs
+++ b/src/group/stabchain/base/selectors/adaptors.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use super::BaseSelector;
 
 /// A struct for partial base selectors
@@ -31,6 +33,37 @@ where
         } else {
             self.second.moved_point(p, pos - self.limit)
         }
+    }
+}
+// Struct for a Partial Selector that first uses a fixed base selector.
+#[derive(Debug, Clone)]
+pub struct PartialFixedBaseSelector<S, T = usize> {
+    selector: PartialSelector<super::FixedBaseSelector<T>, S>,
+}
+
+impl<S, T> PartialFixedBaseSelector<S, T>
+where
+    T: Clone,
+{
+    pub fn new(base: &[T], after_partial: S) -> Self {
+        // Create a partial selector that uses the fixed base first and then the second selector.
+        PartialFixedBaseSelector {
+            selector: PartialSelector::new(
+                super::FixedBaseSelector::new(base),
+                base.len(),
+                after_partial,
+            ),
+        }
+    }
+}
+
+impl<P, OrbitT, S> BaseSelector<P, OrbitT> for PartialFixedBaseSelector<S, OrbitT>
+where
+    OrbitT: Clone + Debug,
+    S: BaseSelector<P, OrbitT>,
+{
+    fn moved_point(&mut self, p: &P, pos: usize) -> OrbitT {
+        self.selector.moved_point(p, pos)
     }
 }
 


### PR DESCRIPTION
One of the desired features was being able to create a stabilizer chain from a partial base. This was possible, but it was a bit awkward using the base selector combinator. Since this is a common use case I thought it'd be good to add this feature, both a new selector (that is just a partial base selector with fixed base as the first base selector) and as a function to create stabilizer chains from.

I did think think of adding a partial base with strategy, but thought it may pollute the namespace a bit much - maybe let me know your thoughts. The new base selector should make things a bit more simple with the general stabchain with strategy or selector.