### PR TITLE
Change RandomShallow to use WordPermutation

### DIFF
--- a/src/group/orbit/transversal/factored_transversal.rs
+++ b/src/group/orbit/transversal/factored_transversal.rs
@@ -62,7 +62,7 @@ where
     if !transversal.contains_key(&point) {
         None
     } else {
-        let mut orbit_point = point.clone();
+        let mut orbit_point = point;
         let mut rep = vec![];
         // Move along the orbit till we reach a representative that the base moves to the point.
         while orbit_point != base {

--- a/src/group/orbit/transversal/factored_transversal.rs
+++ b/src/group/orbit/transversal/factored_transversal.rs
@@ -2,7 +2,6 @@
 
 use super::skeleton::TransversalSkeleton;
 use crate::group::orbit::transversal::Transversal;
-use crate::group::utils::apply_permutation_word;
 use crate::group::Group;
 use crate::perm::actions::SimpleApplication;
 use crate::perm::{Action, DefaultPermutation, Permutation};
@@ -47,6 +46,7 @@ where
     }
 }
 
+#[deprecated(since = "0.1.1")]
 pub(crate) fn representative_raw_as_word<P, S, A>(
     transversal: &HashMap<A::OrbitT, P, S>,
     base: A::OrbitT,
@@ -71,7 +71,6 @@ where
             orbit_point = strat.apply(g_inv, orbit_point);
         }
         rep.reverse();
-        debug_assert!(apply_permutation_word(&rep, base, strat) == point);
         Some(rep)
     }
 }

--- a/src/group/orbit/transversal/shallow_transversal/mod.rs
+++ b/src/group/orbit/transversal/shallow_transversal/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::group::random_perm::RandPerm;
 use crate::group::{utils::apply_permutation_word, Action, Group};
+use crate::perm::impls::word::WordPermutation;
 use crate::perm::Permutation;
 use crate::DetHashMap;
 use rand::seq::SliceRandom;
@@ -116,7 +117,7 @@ pub(crate) fn representative_raw_as_word<P, A>(
     point: A::OrbitT,
     strat: &A,
     depth: usize,
-) -> Option<Vec<P>>
+) -> Option<WordPermutation<P>>
 where
     P: Permutation,
     A: Action<P>,
@@ -127,16 +128,15 @@ where
     } else {
         let mut orbit_point = point.clone();
         // The +1 is because the base point has depth 0.
-        let mut rep = Vec::with_capacity(depth + 1);
+        let mut rep = WordPermutation::id();
         // Move along the orbit till we reach a representative that the base moves to the point.
         while orbit_point != base {
             let g_inv = transversal.get(&orbit_point).unwrap();
-            rep.push(g_inv.inv());
+            rep.multiply_mut(g_inv);
             orbit_point = strat.apply(g_inv, orbit_point);
         }
-        rep.reverse();
-        debug_assert!(apply_permutation_word(&rep, base, strat) == point);
-        debug_assert!(rep.len() <= depth + 1);
+        rep.inv_lazy();
+        debug_assert!(strat.apply(&rep.evaluate(), base) == point);
         Some(rep)
     }
 }

--- a/src/group/orbit/transversal/shallow_transversal/mod.rs
+++ b/src/group/orbit/transversal/shallow_transversal/mod.rs
@@ -1,7 +1,7 @@
 //! Collection of functions that will compute shallow(er) transversals.
 
 use crate::group::random_perm::RandPerm;
-use crate::group::{utils::apply_permutation_word, Action, Group};
+use crate::group::{Action, Group};
 use crate::perm::impls::word::WordPermutation;
 use crate::perm::Permutation;
 use crate::DetHashMap;
@@ -128,16 +128,15 @@ where
     } else {
         let mut orbit_point = point.clone();
         // The +1 is because the base point has depth 0.
-        let mut rep = WordPermutation::id();
+        let mut rep = WordPermutation::id_with_capacity(depth + 1);
         // Move along the orbit till we reach a representative that the base moves to the point.
         while orbit_point != base {
             let g_inv = transversal.get(&orbit_point).unwrap();
             rep.multiply_mut(g_inv);
             orbit_point = strat.apply(g_inv, orbit_point);
         }
-        rep.inv_lazy();
-        debug_assert!(strat.apply(&rep.evaluate(), base) == point);
-        Some(rep)
+        debug_assert!(strat.apply(&rep.inv().evaluate(), base) == point);
+        Some(rep.inv_lazy())
     }
 }
 

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -162,7 +162,7 @@ where
             .flat_map(|g| {
                 subproduct_iter.iter().map(move |w| {
                     let mut gw = g.clone();
-                    gw.multiply_mut_word(&w);
+                    gw.multiply_mut_word(w);
                     gw
                 })
             })
@@ -218,7 +218,7 @@ where
         //Convert these into random schrier generators, by concatenating the resdiue of the inverse to it.
         random_gens.iter_mut().for_each(|gw| {
             //Get the residue of this word
-            let (_, gw_bar) = residue_as_words_from_words(self.current_chain(), &gw);
+            let (_, gw_bar) = residue_as_words_from_words(self.current_chain(), gw);
             //Append the inverse of the residue to the word, to get a schrier generator.
             gw_bar
                 .into_iter()

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -5,13 +5,10 @@ use crate::group::orbit::transversal::shallow_transversal::{
 };
 use crate::group::stabchain::element_testing::residue_as_words_from_words;
 use crate::group::stabchain::{base::selectors::BaseSelector, order, Stabchain, StabchainRecord};
-use crate::group::utils::{
-    apply_permutation_word, collapse_perm_word, random_subproduct_word_full,
-    random_subproduct_word_subset,
-};
+use crate::group::utils::{random_subproduct_word_full, random_subproduct_word_subset};
 use crate::group::Group;
 use crate::perm::actions::SimpleApplication;
-use crate::perm::{Action, Permutation};
+use crate::perm::{impls::word::WordPermutation, Action, Permutation};
 use itertools::Itertools;
 use rand::rngs::ThreadRng;
 use rand::{seq::IteratorRandom, Rng};
@@ -121,7 +118,7 @@ where
         subproducts: usize,
         coset_representatives: usize,
         gens: &[P],
-    ) -> Vec<Vec<P>> {
+    ) -> Vec<WordPermutation<P>> {
         debug!(
             level = self.current_pos,
             "Random generation of Schrier Generators"
@@ -136,7 +133,7 @@ where
         let subproduct_w2_iter =
             repeat_with(|| random_subproduct_word_subset(&mut *self.rng.borrow_mut(), gens, k));
         //Iterleave the two iterators.
-        let subproduct_iter: Vec<Vec<P>> = subproduct_w1_iter
+        let subproduct_iter: Vec<WordPermutation<P>> = subproduct_w1_iter
             .interleave(subproduct_w2_iter)
             .take(2 * subproducts)
             .collect();
@@ -165,7 +162,7 @@ where
             .flat_map(|g| {
                 subproduct_iter.iter().map(move |w| {
                     let mut gw = g.clone();
-                    gw.extend(w.clone());
+                    gw.multiply_mut_word(&w);
                     gw
                 })
             })
@@ -221,9 +218,13 @@ where
         //Convert these into random schrier generators, by concatenating the resdiue of the inverse to it.
         random_gens.iter_mut().for_each(|gw| {
             //Get the residue of this word
-            let (_, gw_bar) = residue_as_words_from_words(self.current_chain(), &gw.clone());
+            let (_, gw_bar) = residue_as_words_from_words(self.current_chain(), &gw);
             //Append the inverse of the residue to the word, to get a schrier generator.
-            gw.extend(gw_bar.iter().map(|p| p.inv()).rev());
+            gw_bar
+                .into_iter()
+                .map(|p| p.inv())
+                .rev()
+                .for_each(|p| gw.multiply_mut(&p));
         });
         //To see if all generators are discarded.
         let mut all_discarded = true;
@@ -257,10 +258,10 @@ where
                             .collect()
                     };
                 //If any point is not fixed by the residue, then we add the residue as a generator.
-                if !self.is_trivial_residue(&h_residue, evaluated_points) {
+                if !h_residue.id_on_iter(evaluated_points) {
                     //Not all permutations have been discarded
                     all_discarded = false;
-                    let h_star = collapse_perm_word(&h_residue);
+                    let h_star = h_residue.evaluate();
                     //Add a new base point, along with a new record for that base point.
                     let new_base_point = self.selector.moved_point(&h_star, self.current_pos);
                     //self.check_transversal_augmentation(h_star);
@@ -286,7 +287,7 @@ where
                 }
             } else {
                 //We have found a residue that has not sifted through, so we add a new base point with this point as a generator.
-                let h_star = collapse_perm_word(&h_residue);
+                let h_star = h_residue.evaluate();
                 //Find the position at which this didn't sift through.
                 let j = self.current_pos + drop_out_level;
                 debug!(perm = %h_star, level = j, "Permutation not sifting through");
@@ -337,11 +338,11 @@ where
             .cloned()
             .collect::<Vec<P>>();
         //Create an iterator that first has the original generators, and then the random schrier generators.
-        let products: Vec<Vec<P>> = self
+        let products: Vec<WordPermutation<P>> = self
             .original_generators
             .generators()
             .iter()
-            .map(|p| vec![p.clone()])
+            .map(|p| WordPermutation::from_perm(p))
             .chain(self.random_schrier_generators_as_word(
                 self.constants.c3,
                 self.constants.c4,
@@ -351,7 +352,7 @@ where
         //Sift the original generators, and all products of the form g*w_{1,2}.
         for p in products {
             //If we have found a non-trivial element, then invoke the sgc at the specified level.
-            if let Some(sgc_invoke_level) = self.sgt_test(&p[..]) {
+            if let Some(sgc_invoke_level) = self.sgt_test(&p) {
                 self.current_pos = sgc_invoke_level;
                 debug!(level = sgc_invoke_level, "SGT failed");
                 self.sgc();
@@ -368,12 +369,12 @@ where
         self.current_pos = original_position;
     }
 
-    fn sgt_test(&mut self, p: &[P]) -> Option<usize> {
+    fn sgt_test(&mut self, p: &WordPermutation<P>) -> Option<usize> {
         let (drop_out_level, residue) = residue_as_words_from_words(self.current_chain(), p);
         //Check if this is a non-trivial residue. If it is then the output of the SGC is correct for this element.
-        if !self.is_trivial_residue_all_points(&residue) {
+        if !residue.id_on_iter(0..self.n) {
             let invoke_level = self.current_pos + drop_out_level;
-            let collapsed_residue = collapse_perm_word(&residue);
+            let collapsed_residue = residue.evaluate();
             //If this point sifted through but isn't trivial, then we need a new record and base point.
             if self.sifted(drop_out_level) {
                 //TODO add function to add a new level
@@ -402,23 +403,6 @@ where
         } else {
             None
         }
-    }
-
-    /// Wrapper function to check all points of the permutation domain.
-    fn is_trivial_residue_all_points(&self, p_as_words: &[P]) -> bool {
-        self.is_trivial_residue(p_as_words, 0..self.n)
-    }
-
-    /// Check if a residue acts trivially on a set of points.
-    /// This is just done by checking that the given permutation fixes all given points.
-    fn is_trivial_residue(
-        &self,
-        p_as_words: &[P],
-        points: impl IntoIterator<Item = A::OrbitT>,
-    ) -> bool {
-        points
-            .into_iter()
-            .all(|x| apply_permutation_word(p_as_words, x, &self.action) == x)
     }
 
     //Utility function to check if a given drop out level is the bottom of the chain.

--- a/src/group/stabchain/element_testing.rs
+++ b/src/group/stabchain/element_testing.rs
@@ -2,7 +2,6 @@
 
 use super::StabchainRecord;
 use crate::group::orbit::abstraction::TransversalResolver;
-use crate::perm::actions::SimpleApplication;
 use crate::perm::impls::word::WordPermutation;
 use crate::perm::{Action, Permutation};
 
@@ -125,18 +124,19 @@ where
 
 /// Sift the permutation word through the chain, returning the residue it generates and the drop out level.
 pub fn residue_as_words_from_words<'a, V, A, P>(
-    it: impl IntoIterator<Item = &'a StabchainRecord<P, V, SimpleApplication<P>>>,
-    p: WordPermutation<P>,
+    it: impl IntoIterator<Item = &'a StabchainRecord<P, V, A>>,
+    p: &WordPermutation<P>,
 ) -> (usize, WordPermutation<P>)
 where
-    V: 'a + TransversalResolver<P, SimpleApplication<P>>,
+    V: 'a + TransversalResolver<P, A>,
     P: 'a + Permutation,
+    A: 'a + Action<P>,
 {
     //This permutation word will store the resulting residue.
     let mut g: WordPermutation<P> = p.clone();
     //This counts how many layers of the chain the permutation sifts through.
     let mut k = 0;
-    let applicator = SimpleApplication::default();
+    let applicator = A::default();
     for record in it {
         let base = record.base.clone();
         let application = applicator.apply_word(&g, base.clone());

--- a/src/group/stabchain/element_testing.rs
+++ b/src/group/stabchain/element_testing.rs
@@ -2,7 +2,8 @@
 
 use super::StabchainRecord;
 use crate::group::orbit::abstraction::TransversalResolver;
-use crate::group::utils::apply_permutation_word;
+use crate::perm::actions::SimpleApplication;
+use crate::perm::impls::word::WordPermutation;
 use crate::perm::{Action, Permutation};
 
 /// Given a stabilizer chain, computes whether the given element is in the group
@@ -123,23 +124,22 @@ where
 }
 
 /// Sift the permutation word through the chain, returning the residue it generates and the drop out level.
-pub fn residue_as_words_from_words<'a, 'b, V, A, P>(
-    it: impl IntoIterator<Item = &'a StabchainRecord<P, V, A>>,
-    p: impl IntoIterator<Item = &'b P>,
-) -> (usize, Vec<P>)
+pub fn residue_as_words_from_words<'a, V, A, P>(
+    it: impl IntoIterator<Item = &'a StabchainRecord<P, V, SimpleApplication<P>>>,
+    p: WordPermutation<P>,
+) -> (usize, WordPermutation<P>)
 where
-    V: 'a + TransversalResolver<P, A>,
-    P: 'a + 'b + Permutation,
-    A: 'a + Action<P>,
+    V: 'a + TransversalResolver<P, SimpleApplication<P>>,
+    P: 'a + Permutation,
 {
     //This permutation word will store the resulting residue.
-    let mut g: Vec<P> = p.into_iter().cloned().collect();
+    let mut g: WordPermutation<P> = p.clone();
     //This counts how many layers of the chain the permutation sifts through.
     let mut k = 0;
-    let applicator = A::default();
+    let applicator = SimpleApplication::default();
     for record in it {
         let base = record.base.clone();
-        let application = apply_permutation_word(&g, base.clone(), &applicator);
+        let application = applicator.apply_word(&g, base.clone());
 
         //There is a missing point, so this permutation has not sifted through.
         if !record.transversal.contains_key(&application) {
@@ -150,7 +150,7 @@ where
             .resolver()
             .representative(&record.transversal, base.clone(), application)
             .unwrap();
-        g.push(representative.inv());
+        g.multiply_mut(&representative.inv());
         k += 1;
     }
     (k, g)

--- a/src/group/utils.rs
+++ b/src/group/utils.rs
@@ -121,26 +121,4 @@ mod tests {
             random_subproduct_subset(&mut rng, g.generators(), 2);
         }
     }
-
-    ///Test that applying a permutation as a word gives the same image as collapsing that permutation.
-    #[test]
-    fn test_apply_permutation_word() {
-        //Test an empty word.
-        let empty_word = vec![];
-        let strat = SimpleApplication::default();
-        assert_eq!(3, apply_permutation_word(&empty_word, 3, &strat));
-        let perm_word: Vec<StandardPermutation> = vec![
-            CyclePermutation::single_cycle(&[1, 2, 4]).into(),
-            CyclePermutation::single_cycle(&[3, 5, 8]).into(),
-            CyclePermutation::single_cycle(&[7, 9]).into(),
-            CyclePermutation::single_cycle(&[1, 5, 6, 9]).into(),
-        ];
-        let collapsed_word = collapse_perm_word(&perm_word);
-        for i in 0..9 {
-            assert_eq!(
-                collapsed_word.apply(i),
-                apply_permutation_word(&perm_word, i, &strat)
-            );
-        }
-    }
 }

--- a/src/group/utils.rs
+++ b/src/group/utils.rs
@@ -1,7 +1,8 @@
 //! Group utilities which I was not sure where to place
 
 use super::Group;
-use crate::perm::{Action, Permutation};
+use crate::perm::impls::word::WordPermutation;
+use crate::perm::Permutation;
 use rand::seq::SliceRandom;
 use rand::Rng;
 
@@ -41,7 +42,7 @@ where
 }
 
 /// Generate a word representation of a random subproduct of the given generators.
-pub fn random_subproduct_word_subset<R, P>(rng: &mut R, gens: &[P], k: usize) -> Vec<P>
+pub fn random_subproduct_word_subset<R, P>(rng: &mut R, gens: &[P], k: usize) -> WordPermutation<P>
 where
     P: Permutation,
     R: Rng,
@@ -50,11 +51,11 @@ where
     gens.choose_multiple(rng, k)
         .filter(|_| rng.gen::<bool>())
         .cloned()
-        .collect::<Vec<P>>()
+        .collect()
 }
 
 /// Generate random subproduct of the given generators.
-pub fn random_subproduct_word_full<T, P>(rng: &mut T, gens: &[P]) -> Vec<P>
+pub fn random_subproduct_word_full<T, P>(rng: &mut T, gens: &[P]) -> WordPermutation<P>
 where
     P: Permutation,
     T: Rng,
@@ -65,7 +66,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perm::actions::SimpleApplication;
     use crate::perm::export::CyclePermutation;
     use crate::perm::impls::standard::StandardPermutation;
     use rand::thread_rng;

--- a/src/group/utils.rs
+++ b/src/group/utils.rs
@@ -24,30 +24,6 @@ where
     random_subproduct_subset(rng, gens, gens.len())
 }
 
-/// Apply a point to permutations stored as a word.
-pub fn apply_permutation_word<'a, P, A>(
-    perm_word: impl IntoIterator<Item = &'a P>,
-    x: A::OrbitT,
-    strat: &A,
-) -> A::OrbitT
-where
-    P: 'a + Permutation,
-    A: Action<P>,
-{
-    perm_word
-        .into_iter()
-        .fold(x, |accum, p| strat.apply(p, accum))
-}
-
-/// Convert from a permutation stored as a word, into a single permutation.
-pub fn collapse_perm_word<'a, P>(p: impl IntoIterator<Item = &'a P>) -> P
-where
-    P: 'a + Permutation,
-{
-    p.into_iter()
-        .fold(Permutation::id(), |accum, perm| accum.multiply(perm))
-}
-
 /// Generate a random subproduct of a random k sized subset of the given generators.
 pub fn random_subproduct_subset<R, P>(rng: &mut R, gens: &[P], k: usize) -> P
 where

--- a/src/perm/actions.rs
+++ b/src/perm/actions.rs
@@ -21,6 +21,15 @@ where
     }
 }
 
+impl<P> SimpleApplication<P>
+where
+    P: Permutation,
+{
+    pub(crate) fn apply_word(&self, p: &WordPermutation<P>, input: usize) -> usize {
+        p.into_iter().fold(input, |x, f| f.apply(x))
+    }
+}
+
 /// Action is on permutation, and it is done by conjugation (p^-1 a p)
 #[derive(Debug, Clone)]
 pub struct ConjugationAction<P>(std::marker::PhantomData<P>);

--- a/src/perm/actions.rs
+++ b/src/perm/actions.rs
@@ -19,14 +19,12 @@ where
     fn apply(&self, p: &P, input: Self::OrbitT) -> Self::OrbitT {
         p.apply(input)
     }
-}
 
-impl<P> SimpleApplication<P>
-where
-    P: Permutation,
-{
-    pub(crate) fn apply_word(&self, p: &WordPermutation<P>, input: usize) -> usize {
-        p.into_iter().fold(input, |x, f| f.apply(x))
+    fn apply_word(&self, p: &WordPermutation<P>, input: Self::OrbitT) -> Self::OrbitT
+    where
+        P: Permutation,
+    {
+        p.apply(input)
     }
 }
 
@@ -87,9 +85,11 @@ mod tests {
                 fn test_identity() {
                     let act = <$id>::default();
                     let id = DefaultPermutation::id();
+                    let id_word = WordPermutation::id();
                     let testing_set = $testing;
                     for i in testing_set {
                         assert_eq!(act.apply(&id, i.clone()), i);
+                        assert_eq!(act.apply_word(&id_word, i.clone()), i);
                     }
                 }
 

--- a/src/perm/impls/word.rs
+++ b/src/perm/impls/word.rs
@@ -70,6 +70,18 @@ where
     }
 }
 
+impl<P> IntoIterator for WordPermutation<P>
+where
+    P: Permutation,
+{
+    type Item = P;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.word.into_iter()
+    }
+}
+
 impl<P> PartialEq for WordPermutation<P>
 where
     P: Permutation,

--- a/src/perm/impls/word.rs
+++ b/src/perm/impls/word.rs
@@ -13,9 +13,20 @@ impl<P> WordPermutation<P>
 where
     P: Permutation,
 {
+    /// Custom initialiser that can take a vector capacity.
+    pub(crate) fn id_with_capacity(capacity: usize) -> Self {
+        WordPermutation {
+            word: Vec::with_capacity(capacity),
+        }
+    }
+
     /// Make from a slice
     pub fn from_slice(perms: &[P]) -> Self {
         perms.iter().cloned().collect()
+    }
+
+    pub fn from_perm(p: &P) -> Self {
+        iter::once(p.clone()).collect()
     }
 
     /// Get an underlying permutation
@@ -33,6 +44,11 @@ where
     /// Check for equality on the given base.
     pub fn eq_on_base(&self, other: &Self, base: &[usize]) -> bool {
         self.eq_on_iter(other, base.iter().copied())
+    }
+
+    /// Check that this acts as the identity on a general iterator. Note that true on 0..=self.lmp() <+ self.lmp_upper() will imply it is actually the identity.
+    pub fn id_on_iter(&self, iter: impl IntoIterator<Item = usize>) -> bool {
+        iter.into_iter().all(|x| self.apply(x) == x)
     }
 
     /// Get an upper bound on the lmp. Note lmp_upper == None => self == id
@@ -192,6 +208,22 @@ where
 mod tests {
     use super::*;
     use crate::perm::{DefaultPermutation, Permutation};
+
+    #[test]
+    fn inv_lazy() {
+        let images = vec![
+            vec![0, 2, 1],
+            vec![0, 1, 2, 4, 3],
+            vec![0, 1, 2, 3, 4, 5, 7, 6],
+        ];
+        let perms = images
+            .iter()
+            .map(|arr| DefaultPermutation::from_images(arr));
+        let perm = WordPermutation::from_iter(perms);
+        assert_eq!(perm.inv_lazy().evaluate(), perm.inv().evaluate());
+        let id = WordPermutation::<DefaultPermutation>::id();
+        assert_eq!(id.inv_lazy().evaluate(), id.inv().evaluate());
+    }
 
     #[test]
     fn lmp_identity() {

--- a/src/perm/impls/word.rs
+++ b/src/perm/impls/word.rs
@@ -52,6 +52,11 @@ where
     pub fn multiply_mut(&mut self, other: &P) {
         self.word.push(other.clone());
     }
+
+    /// Multiply in place by another word.
+    pub fn multiply_mut_word(&mut self, other: &Self) {
+        self.word.extend(other.word.iter().cloned());
+    }
 }
 
 impl<P> FromIterator<P> for WordPermutation<P>

--- a/src/perm/impls/word.rs
+++ b/src/perm/impls/word.rs
@@ -39,6 +39,19 @@ where
     pub fn lmp_upper(&self) -> Option<usize> {
         self.word.iter().flat_map(|p| p.lmp()).max()
     }
+
+    /// Lazily evaluate the inverse of the permutation, using the identify (ab)^-1 = b^-1a^-1
+    pub fn inv_lazy(&self) -> Self {
+        // We know each word is not the identity, so it's inverse isn't either.
+        WordPermutation {
+            word: self.word.iter().map(|p| p.inv()).rev().collect(),
+        }
+    }
+
+    /// Multiply in place.
+    pub fn multiply_mut(&mut self, other: &P) {
+        self.word.push(other.clone());
+    }
 }
 
 impl<P> FromIterator<P> for WordPermutation<P>

--- a/src/perm/mod.rs
+++ b/src/perm/mod.rs
@@ -81,6 +81,14 @@ pub trait Action<P>: Default + Clone + Debug {
     /// Apply the action. Required to satisfy (1) action.apply(P::id, i) == i.
     /// (2) action.apply(a b, i) == action.apply(b, action.apply(a, i))
     fn apply(&self, p: &P, input: Self::OrbitT) -> Self::OrbitT;
+
+    /// Same as apply, but can work for permutation words.
+    fn apply_word(&self, p: &WordPermutation<P>, input: Self::OrbitT) -> Self::OrbitT
+    where
+        P: Permutation,
+    {
+        self.apply(&p.evaluate(), input)
+    }
 }
 
 macro_rules! impl_conversions {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -128,6 +128,7 @@ fn test_transversals() {
 macro_rules! test_stabilizer_on_strategy {
     ($strategy:expr, $short:ident, $error: expr) => {
         #[test]
+        #[allow(deprecated)]
         fn $short() {
             general_test(
                 stringify!($short),
@@ -146,6 +147,7 @@ macro_rules! test_stabilizer_on_strategy {
 macro_rules! test_stabilizer_on_strategy_with_order {
     ($strategy:expr, $short:ident, $error: expr) => {
         #[test]
+        #[allow(deprecated)]
         fn $short() {
             general_test(
                 stringify!($short),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -128,7 +128,6 @@ fn test_transversals() {
 macro_rules! test_stabilizer_on_strategy {
     ($strategy:expr, $short:ident, $error: expr) => {
         #[test]
-        #[allow(deprecated)]
         fn $short() {
             general_test(
                 stringify!($short),
@@ -147,7 +146,6 @@ macro_rules! test_stabilizer_on_strategy {
 macro_rules! test_stabilizer_on_strategy_with_order {
     ($strategy:expr, $short:ident, $error: expr) => {
         #[test]
-        #[allow(deprecated)]
         fn $short() {
             general_test(
                 stringify!($short),


### PR DESCRIPTION
This changed the implementation of RandomShallow to use WordPermutations instead of vectors of permutations directly. As a result of this some things needed to be moved into the old random implementation, as they relied on the functions that operated on vectors.

As part of this a new function was added to the action trait, that allows actions to be applied to words. This has a default implementation to just evaluate the word.

This shouldn't be slower, but I'll wait on the benchmarks to check