### PR TITLE
Multiplication optimisation

### DIFF
--- a/src/perm/impls/mod.rs
+++ b/src/perm/impls/mod.rs
@@ -107,6 +107,19 @@ macro_rules! permutation_tests {
                 );
             }
 
+            /// Check that multiplication for larger/smaller degree permutations works
+            ///
+            /// This is for any implementations that may treat these as special cases
+            #[test]
+            fn mult_perm_different_sizes() {
+                let perm1 = <$name>::from_images(&[1, 5, 4, 0, 2, 3]);
+                let perm2 = <$name>::from_images(&[3, 2, 0, 1]);
+                let perm1_perm2 = <$name>::from_images(&[2, 5, 4, 3, 0, 1]);
+                let perm2_perm1 = <$name>::from_images(&[0, 4, 1, 5, 2, 3]);
+                assert_eq!(perm1.multiply(&perm2), perm1_perm2);
+                assert_eq!(perm2.multiply(&perm1), perm2_perm1);
+            }
+
             /// Test that multiplication for the lazy or eager implementaions are identical
             #[test]
             fn mult_perm_lazy_eager() {

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -113,7 +113,7 @@ impl Permutation for StandardPermutation {
                 result
             } else {
                 // Otherwise we can skip bounds checking for self
-                (0..(self_size + 1))
+                (0..self_size + 1)
                     .map(|x| other.apply(self.vals[x]))
                     .collect()
             };

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -96,23 +96,29 @@ impl Permutation for StandardPermutation {
         } else {
             let self_size = self.lmp().unwrap_or(0);
             let other_size = other.lmp().unwrap_or(0);
-            let size = max(self_size, other_size);
             debug_assert!(self_size > 0);
             debug_assert!(other_size > 0);
             // Special case for if the lhs or rhs is of smaller degree
             // If lhs is of smaller degree, we can just copy the values for the larger degree rhs permutation and we do not need to bounds check.
             let v: Vec<usize> = if self_size <= other_size {
                 // We can skip bounds checking in this case, and ignore lhs for larger points.
-                (0..=self_size)
-                    .map(|x| other.vals[self.vals[x]])
-                    .chain((self_size + 1..=other_size).map(|x| other.vals[x]))
-                    .collect()
+                // This would be much nicer as an iterator, but chain is slow.
+                let mut result = Vec::with_capacity(other_size + 1);
+                for i in 0..(self_size + 1) {
+                    result.push(other.vals[self.vals[i]]);
+                }
+                for i in (self_size + 1)..(other_size + 1) {
+                    result.push(other.vals[i]);
+                }
+                result
             } else {
                 // Otherwise we can skip bounds checking for self
-                (0..=size).map(|x| other.apply(self.vals[x])).collect()
+                (0..(self_size + 1))
+                    .map(|x| other.apply(self.vals[x]))
+                    .collect()
             };
             // TODO check for premultiplying inverses if both exist
-            debug_assert!(v.len() == size + 1);
+            debug_assert!(v.len() == max(self_size, other_size) + 1);
             StandardPermutation::from_vec_unchecked(v)
         }
     }

--- a/src/perm/impls/standard.rs
+++ b/src/perm/impls/standard.rs
@@ -100,18 +100,18 @@ impl Permutation for StandardPermutation {
             debug_assert!(self_size > 0);
             debug_assert!(other_size > 0);
             // Special case for if the lhs or rhs is of smaller degree
-            let v: Vec<usize>;
             // If lhs is of smaller degree, we can just copy the values for the larger degree rhs permutation and we do not need to bounds check.
-            if self_size <= other_size {
+            let v: Vec<usize> = if self_size <= other_size {
                 // We can skip bounds checking in this case, and ignore lhs for larger points.
-                v = (0..=self_size)
+                (0..=self_size)
                     .map(|x| other.vals[self.vals[x]])
                     .chain((self_size + 1..=other_size).map(|x| other.vals[x]))
-                    .collect();
+                    .collect()
             } else {
                 // Otherwise we can skip bounds checking for self
-                v = (0..=size).map(|x| other.apply(self.vals[x])).collect();
-            }
+                (0..=size).map(|x| other.apply(self.vals[x])).collect()
+            };
+            // TODO check for premultiplying inverses if both exist
             debug_assert!(v.len() == size + 1);
             StandardPermutation::from_vec_unchecked(v)
         }


### PR DESCRIPTION
I've found a few ways that the multiplication can be slightly optimised. It's not a massive speedup for the individual multiplications, but this does add up for the stabiliser chains

- First we weren't treating the lhs being the identity as a special case, so we now just clone the rhs (it doesn't matter if this is the identity too, as cloning is very cheap and we'll just be cloning the identity)
- The second is if the rhs and lhs are different sizes, as we can omit some of the bounds checking that is performed by apply (it would be possible to do unsafe accesses bypassing the vec bounds checks, but this is enough for now I'd say).
- Using exclusive ranges instead of inclusive ones, as these are known to often be faster.

It does make the multiplication code less nice, but unfortunately as chaining iterators can be slow I've just reverted to good old for loops.