### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.43.0 # MSRV
+          - 1.46.0 # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ version = "0.1.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-itertools = "0.9"
-num = "0.3"
-num-bigint = {version = "0.3", features = ["serde"]}
+itertools = "0.10.1"
+num = "0.4"
+num-bigint = {version = "0.4", features = ["serde"]}
 rand = "0.8"
 serde = {version = "1.0", features = ["derive", "rc"]}
 tracing = "0.1"
 
 [dev-dependencies]
-criterion = "0.3"
-indicatif = "0.15"
+criterion = "0.3.5"
+indicatif = "0.16.2"
 lazy_static = "1.4"
 rand_xorshift = "0.3"
 rayon = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Giacomo Fenzi <giacomofenzi@outlook.com>", "Ewan Gilligan <ewan.gilligan@gmail.com>"]
 edition = "2018"
 name = "stabchain"
-version = "0.1.1"
+version = "0.1.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,21 +10,21 @@ version = "0.1.1"
 itertools = "0.10.1"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["serde"]}
-rand = "0.8"
+rand = "0.8.4"
 serde = {version = "1.0", features = ["derive", "rc"]}
-tracing = "0.1"
+tracing = "0.1.26"
 
 [dev-dependencies]
 criterion = "0.3.5"
 indicatif = "0.16.2"
 lazy_static = "1.4"
 rand_xorshift = "0.3"
-rayon = "1.5"
-serde_json = {version = "1.0", features = ["arbitrary_precision"]}
-structopt = "0.3"
-tracing-subscriber = "0.2"
-walkdir = "2"
-zip = "0.5"
+rayon = "1.5.1"
+serde_json = {version = "1.0.66", features = ["arbitrary_precision"]}
+structopt = "0.3.22"
+tracing-subscriber = "0.2.19"
+walkdir = "2.3.2"
+zip = "0.5.13"
 
 # Needed as otherwise cargo tries to run benchmarks as tests and messes cmdline args
 [lib]

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -74,7 +74,7 @@ fn bench<S: BuilderStrategy<DefaultPermutation> + Clone>(lib: Vec<DecoratedGroup
     }
     let duration = start.elapsed();
 
-    progress_bar.finish_with_message(&format!("Finished in {:?}", duration));
+    progress_bar.finish_with_message(format!("Finished in {:?}", duration));
 
     println!("Finished in {:?}", duration);
 }


### PR DESCRIPTION
This pull request updates the dependencies. The CI was failing due to clap not compiling. I updated the dependencies to debug this, but realised the issue was that our MSRV was only 1.43.0 and clap required if and match in const fn's. So I've also updated the MSRV to 1.46.0 to fix this.