### PR TITLE
Iterative random

### DIFF
--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -349,14 +349,14 @@ where
             let (drop_out_level, h_residue) = residue_as_words_from_words(self.full_chain(), &h);
             if self.sifted(drop_out_level) {
                 //Pick the points that should be evaluated. This is a heuristic to speed up run times.
-                let evaluated_points: Vec<A::OrbitT> =
-                    if self.chain[level].transversal.len() <= self.constants.orbit_bound {
+                let evaluated_points: Vec<A::OrbitT> = {
+                    let transversal = &self.chain[level].transversal;
+                    if transversal.len() <= self.constants.orbit_bound {
                         //Evaluate on all points of the current orbit.
-                        self.chain[level].transversal.keys().cloned().collect()
+                        transversal.keys().cloned().collect()
                     } else if self.base.len() <= self.constants.base_bound {
                         //Evaluate on BASE_BOUND randomly chosen points.
-                        self.chain[level]
-                            .transversal
+                        transversal
                             .keys()
                             .choose_multiple(&mut *self.rng.borrow_mut(), self.constants.base_bound)
                             .into_iter()
@@ -367,17 +367,18 @@ where
                         let b_star = self
                             .base
                             .iter()
-                            .filter(|&b| self.chain[level].transversal.contains_key(b))
+                            .filter(|&b| transversal.contains_key(b))
                             .count();
                         //Evaluate on b_star randomly chosen points.
-                        self.chain[level]
-                            .transversal
+
+                        transversal
                             .keys()
                             .choose_multiple(&mut *self.rng.borrow_mut(), b_star)
                             .into_iter()
                             .cloned()
                             .collect()
-                    };
+                    }
+                };
                 //We have found a residue that has not sifted through, so we add a new base point with this point as a generator.
                 if !h_residue.id_on_iter(evaluated_points) {
                     //Not all permutations have been discarded

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -3,7 +3,6 @@ use crate::group::orbit::abstraction::FactoredTransversalResolver;
 use crate::group::orbit::transversal::shallow_transversal::{
     representative_raw_as_word, shallow_transversal,
 };
-use crate::group::random_perm::RandPerm;
 use crate::group::stabchain::element_testing::residue_as_words_from_words;
 use crate::group::stabchain::{base::selectors::BaseSelector, order, Stabchain, StabchainRecord};
 use crate::group::utils::{random_subproduct_word_full, random_subproduct_word_subset};
@@ -245,7 +244,7 @@ where
         // We now check if a new shallow transversal is required, or the new one will not exceed the depth.
         let mut recompute_transversal = false;
         // First partion points at maximum depth and those not.
-        let max_depth = self.max_depths[self.current_pos];
+        let max_depth = self.max_depths[level];
         let (max_depth_points, mut to_check): (VecDeque<usize>, VecDeque<usize>) = self.depths
             [level]
             .keys()
@@ -526,7 +525,7 @@ where
 
     /// Add a new level to the chain, starting with this permutation.
     fn add_new_record(&mut self, gen: P) {
-        let moved_point = self.selector.moved_point(&gen, self.current_pos);
+        let moved_point = self.selector.moved_point(&gen, self.base.len());
         debug!(perm = %gen, moved_point = moved_point, "Extending chain");
         let mut gens = Group::new(&[gen]);
         let (transversal, depth) = shallow_transversal(

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -411,6 +411,7 @@ where
             if level == 0 {
                 None
             } else {
+                // Otherwise proceed at level - 1
                 Some(level - 1)
             }
         // Check the order for an early exit, as we know that something new has been added.
@@ -419,9 +420,9 @@ where
         {
             None
         } else {
+            // Continue with SGC.
             Some(invoke_level)
         }
-        // Continue with SGC.
     }
 
     fn sgt(&mut self) -> Option<usize> {
@@ -495,11 +496,7 @@ where
             .map(|p| WordPermutation::from_perm(p))
             .collect();
         gens.extend(self.original_generators.generators().iter().cloned());
-        // // copy the rng to supply to the perm generator
-        // let mut rng = self.rng.borrow().clone();
-        // //Create an iterator that first has the original generators, and then the random schrier generators.
-        // let mut random = RandPerm::new(11, &Group::new(&gens), 50, &mut rng);
-        //Sift the original generators, and all products of the form g*w_{1,2}.
+        //Sift the original generators, and products of the form g*w_{1,2}.
         while size != order(self.chain.iter()) {
             while products.is_empty() {
                 products.extend(self.random_schrier_generators_as_word(

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -327,12 +327,7 @@ where
 
     fn sgc(&mut self, level: usize) -> Option<usize> {
         trace!(level = level, "Strong Generating Set Construction");
-        //Number of base points than are in the current orbit.
-        let b_star = self
-            .base
-            .iter()
-            .filter(|&b| self.chain[level].transversal.contains_key(b))
-            .count();
+        // Take union of generating sets.
         let gens = self.union_gen_set(level);
         //Random products of the form gw
         let random_gens = self.random_schrier_generators_as_word(
@@ -368,6 +363,12 @@ where
                             .cloned()
                             .collect()
                     } else {
+                        //Number of base points than are in the current orbit.
+                        let b_star = self
+                            .base
+                            .iter()
+                            .filter(|&b| self.chain[level].transversal.contains_key(b))
+                            .count();
                         //Evaluate on b_star randomly chosen points.
                         self.chain[level]
                             .transversal

--- a/src/group/stabchain/builder/random/random_strees.rs
+++ b/src/group/stabchain/builder/random/random_strees.rs
@@ -327,12 +327,11 @@ where
 
     fn sgc(&mut self, level: usize) -> Option<usize> {
         trace!(level = level, "Strong Generating Set Construction");
-        let record = self.chain[level].clone();
         //Number of base points than are in the current orbit.
         let b_star = self
             .base
             .iter()
-            .filter(|&b| record.transversal.contains_key(b))
+            .filter(|&b| self.chain[level].transversal.contains_key(b))
             .count();
         let gens = self.union_gen_set(level);
         //Random products of the form gw
@@ -356,12 +355,12 @@ where
             if self.sifted(drop_out_level) {
                 //Pick the points that should be evaluated. This is a heuristic to speed up run times.
                 let evaluated_points: Vec<A::OrbitT> =
-                    if record.transversal.len() <= self.constants.orbit_bound {
+                    if self.chain[level].transversal.len() <= self.constants.orbit_bound {
                         //Evaluate on all points of the current orbit.
-                        record.transversal.keys().cloned().collect()
+                        self.chain[level].transversal.keys().cloned().collect()
                     } else if self.base.len() <= self.constants.base_bound {
                         //Evaluate on BASE_BOUND randomly chosen points.
-                        record
+                        self.chain[level]
                             .transversal
                             .keys()
                             .choose_multiple(&mut *self.rng.borrow_mut(), self.constants.base_bound)
@@ -370,7 +369,7 @@ where
                             .collect()
                     } else {
                         //Evaluate on b_star randomly chosen points.
-                        record
+                        self.chain[level]
                             .transversal
                             .keys()
                             .choose_multiple(&mut *self.rng.borrow_mut(), b_star)


### PR DESCRIPTION
This converts the shallow random implementation into an iterative procedure, instead of a recursive one. I found that for some large benchmarks, the call stack was running out of space.  This also ends up fixing some control flow issues that happened to be working out due to randomness working out.

This also (in my opinion) makes the implementation clearer, as now each operation returns an invoke level for the strong generator construction to continue on (or not if it is complete).